### PR TITLE
feat: [PAYMCLOUD-308] Add managed Grafana dashboard and update Terraform modules

### DIFF
--- a/src/40_platform/.terraform.lock.hcl
+++ b/src/40_platform/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/grafana/grafana" {
+  version     = "2.19.4"
+  constraints = "~> 2.3"
+  hashes = [
+    "h1:XjYARXNAS1YMgABhI5J3RknJbHvh/DjlVOcywc5I5w4=",
+    "zh:10e1db6012433e84592cee299e7014deda1d9772f86f0f6f635e9d46543ebf25",
+    "zh:2ef424112ff8b6fbd6ea918b3d1498af6bcbd5407b8adc862ad892b1ff3f7047",
+    "zh:34697e3abbef0b01b883792983bcf0f9e55c131ce3afa167f76b8712384fbc50",
+    "zh:4961c3de106e3b78cfb5cfc01946d17e062de274cacd60365f020a92c86a98f9",
+    "zh:4eca84134b1ce5deb018246a87635677afce64689a72fef9a10b37b4d09cf47f",
+    "zh:84568baf9deaa220c02e4b1b6797f1cb09547340baa07a0c1dbc53725275fd6e",
+    "zh:956baf9dc58d4e6bdcc1148fc30b1a7ce0cf251e01d8c4e1c0249226be550d94",
+    "zh:ad185a8c63c99f0408f4e6f3174c2854817143c59fd15f91771048e4ad91f6e5",
+    "zh:c5a92a4089f21278cc214051895ad51b62e8420df1c310ade752f79c1379167d",
+    "zh:da8b458d27434d775f482751a11a167a39fe9ba6c293e085116201def3d68437",
+    "zh:de2d4f5c12799ee65f478ca7a8f90d48e0944b19b7918da841e167f175627278",
+    "zh:e1cb92c84cbe42a8f2a54c2af70da4d85a131c7e5d82ac389451d2619f492a58",
+    "zh:e836db1d0d1fa1c9618c3c0fec254c954d36cd0d9d11d39e74b3cdfdfaed053c",
+    "zh:f0c7ae3fbcd2651348f1d8ec455f61eae59fd8a06cf97778b53c7b91bd0b981b",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azuread" {
   version     = "2.53.1"
   constraints = "~> 2.53"
@@ -22,22 +44,22 @@ provider "registry.terraform.io/hashicorp/azuread" {
 }
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "4.19.0"
+  version     = "4.23.0"
   constraints = "~> 4.0"
   hashes = [
-    "h1:Dp5Yah8qu2ulwCdA8/Rv4vAiNkyE3xz7ElmujrY60oE=",
-    "zh:1f4c852bdba8b9d98259cd190af195120a088c12819037e73c5c654197779b04",
-    "zh:2531bd0c0279958f6f3a1d17a48a39cc5ccaa3d2d0becce6def412aeb4439991",
-    "zh:3d1d510390041581f10fda5093e2f2dbda34c36fc64550b3a86f895dc3441c44",
-    "zh:5f4d22484a2d3742efd390f185f7541d857d3349c50f41112945f6d34bdd7da4",
-    "zh:64e883bfd5d28687c1b6af00d6bb86333b9f9822d5775065c3465b39c839caaf",
-    "zh:731812c3f8459f12517af20fb63d1eba33e062c6f3832dcbde33fa6e131cd86e",
-    "zh:7eb714ff68c286333cc2b093a2d9c011c6a1c283c7aa663e4fb101d2e2e6658b",
-    "zh:855de9d923530f2d207489d4b904a20d32a8ea0f7c639f1f052394ef5cb35422",
-    "zh:95d0fa6868d07ff4399ca269039aead4dff33fbbd0e5ed8062f04a5e62076cd2",
-    "zh:9dcdf840c43ac7dd39cf732a3289fb79b834b5f1bcdaa866111d13b4ee7842d4",
-    "zh:a47776beb983a4f6a635094a9de41916337c50089c4bc628d8c7fa9ca042dd92",
+    "h1:fHnHlU3IjCzpmsZRIT1Wrpjau/V27e1Z1xv3IdfOLVU=",
+    "zh:08d950618a2bf14445171a0eae3721b69be731d6732fad72e902e56e49d4d3b0",
+    "zh:1a9c84376a30cc890830d433ec21057417c012135b40af672dc915010160595a",
+    "zh:2db0422d03840b078a03a33599bbd1f6ea9569bf38ef2a2b99e6bcfc65e14400",
+    "zh:35884b51dcf73acc5fcc0ea22414226e4c3709798fac8948239d8601bfd23592",
+    "zh:5d84f4f588b478bbb7f4f3a943d722c9c14177b8003347b2d29978271bc19632",
+    "zh:5e232ba768cf8d7eb0adcf599f93cd89253f9c2af8e22160451ba6e0c7799101",
+    "zh:80807af8909c00df853c13b9cf363ba31ce013733ef353ac206f81033a1747fa",
+    "zh:8ced180e4377e5cd8a5138ec7eb64493ace692f5e5aa8bb5681154f431232f8a",
+    "zh:bd5b5cbbd0b38b91217251c1d977410bc930f11063e4e97c798c834dc00ef369",
+    "zh:c021b1ecf0a3c02bbb56d8e8ac14bdde04e9c1e5b2346563b53450aea468847e",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fc036967ce8f8322c91e93b20af0b68512df177018e975d742a91445d6b94b37",
   ]
 }
 

--- a/src/40_platform/00_data.tf
+++ b/src/40_platform/00_data.tf
@@ -3,6 +3,10 @@ data "azuread_group" "adgroup_admin" {
   display_name = "${local.product}-adgroup-admin"
 }
 
+data "azuread_group" "adgroup_developers" {
+  display_name = "${local.product}-adgroup-developers"
+}
+
 #
 # Network
 #
@@ -17,13 +21,22 @@ data "azurerm_private_dns_zone" "storage_account_table" {
 }
 
 #
-# KV
+# 🔐 KV
 #
+
+# CICD
 data "azurerm_key_vault" "cicd_kv" {
   name                = local.kv_cicd_name
   resource_group_name = local.kv_cicd_resource_group_name
 }
 
+# CORE
+data "azurerm_key_vault" "core_kv" {
+  name                = local.kv_core_name
+  resource_group_name = local.kv_core_resource_group_name
+}
+
+# Secrets
 data "azurerm_key_vault_secret" "email_google_cstar_status" {
   name         = "email-google-group-cstar-status"
   key_vault_id = data.azurerm_key_vault.cicd_kv.id

--- a/src/40_platform/11_subnets.tf
+++ b/src/40_platform/11_subnets.tf
@@ -3,7 +3,7 @@
 #
 module "synthetic_snet" {
   # source = "./.terraform/modules/__v4__/subnet"
-  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git//subnet?ref=synthetic-improvements"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git//subnet?ref=v1.20.0"
 
   name                 = "${local.project}-synthetic-snet"
   resource_group_name  = data.azurerm_virtual_network.vnet_platform.resource_group_name
@@ -26,7 +26,7 @@ module "synthetic_snet" {
 #
 module "storage_private_endpoint_snet" {
   # source = "./.terraform/modules/__v3__/subnet"
-  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git//subnet?ref=synthetic-improvements"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git//subnet?ref=v1.20.0"
 
   resource_group_name  = data.azurerm_virtual_network.vnet_platform.resource_group_name
   virtual_network_name = data.azurerm_virtual_network.vnet_platform.name
@@ -41,7 +41,7 @@ module "storage_private_endpoint_snet" {
 
 module "container_app_private_endpoint_snet" {
   # source = "./.terraform/modules/__v3__/subnet"
-  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git//subnet?ref=synthetic-improvements"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git//subnet?ref=v1.20.0"
 
   resource_group_name  = data.azurerm_virtual_network.vnet_platform.resource_group_name
   virtual_network_name = data.azurerm_virtual_network.vnet_platform.name

--- a/src/40_platform/20_synthetic.tf
+++ b/src/40_platform/20_synthetic.tf
@@ -53,9 +53,7 @@ resource "azurerm_private_endpoint" "private_endpoint_container_app" {
 
 module "synthetic_monitoring_jobs" {
   # source     = "./.terraform/modules/__v4__/monitoring_function"
-  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git//monitoring_function?ref=synthetic-improvements"
-
-  depends_on = [azurerm_application_insights.monitoring_application_insights]
+  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git//monitoring_function?ref=v1.20.0"
 
   location            = var.location
   prefix              = "${local.product}-${var.location_short}"

--- a/src/40_platform/30_grafana_managed.tf
+++ b/src/40_platform/30_grafana_managed.tf
@@ -1,4 +1,6 @@
-
+#
+# 📊Grafana Managed
+#
 resource "azurerm_dashboard_grafana" "grafana_dashboard" {
   name                              = "${local.product}-${var.location_short}-grafana"
   resource_group_name               = azurerm_resource_group.monitoring_rg.name

--- a/src/40_platform/30_grafana_managed.tf
+++ b/src/40_platform/30_grafana_managed.tf
@@ -1,0 +1,41 @@
+
+resource "azurerm_dashboard_grafana" "grafana_dashboard" {
+  name                              = "${local.product}-${var.location_short}-grafana"
+  resource_group_name               = azurerm_resource_group.monitoring_rg.name
+  location                          = var.location
+  api_key_enabled                   = true
+  deterministic_outbound_ip_enabled = true
+  public_network_access_enabled     = true
+  zone_redundancy_enabled           = false
+  grafana_major_version             = 10
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = var.tags
+}
+
+#
+# 👤 Users & Groups IAM
+#
+resource "azurerm_role_assignment" "grafana_dashboard_monitoring_reader_identity" {
+  scope                = data.azurerm_subscription.current.id
+  role_definition_name = "Monitoring Reader"
+  principal_id         = azurerm_dashboard_grafana.grafana_dashboard.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "grafana_dashboard_monitoring_reader" {
+  scope                = data.azurerm_subscription.current.id
+  role_definition_name = "Grafana Viewer"
+  principal_id         = data.azuread_group.adgroup_developers.id
+}
+
+#
+# 👷🏻‍♂️ Admins IAM
+#
+resource "azurerm_role_assignment" "grafana_dashboard_monitoring_admins" {
+  scope                = data.azurerm_subscription.current.id
+  role_definition_name = "Grafana Admin"
+  principal_id         = data.azuread_group.adgroup_admin.id
+}

--- a/src/40_platform/99_locals.tf
+++ b/src/40_platform/99_locals.tf
@@ -21,6 +21,9 @@ locals {
   kv_cicd_name                = "${local.product_nodomain}-cicd-kv"
   kv_cicd_resource_group_name = "${local.product_nodomain}-core-sec-rg"
 
+  kv_core_name                = "${local.product_nodomain}-core-kv"
+  kv_core_resource_group_name = "${local.product_nodomain}-core-sec-rg"
+
   #
   # Domain urls
   #

--- a/src/40_platform/README.md
+++ b/src/40_platform/README.md
@@ -13,17 +13,17 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.53.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.19.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.23.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | 80b6cf16e70fd176ad7de10c4027f9ad791d7c6a |
-| <a name="module_container_app_private_endpoint_snet"></a> [container\_app\_private\_endpoint\_snet](#module\_container\_app\_private\_endpoint\_snet) | git::https://github.com/pagopa/terraform-azurerm-v4.git//subnet | synthetic-improvements |
-| <a name="module_storage_private_endpoint_snet"></a> [storage\_private\_endpoint\_snet](#module\_storage\_private\_endpoint\_snet) | git::https://github.com/pagopa/terraform-azurerm-v4.git//subnet | synthetic-improvements |
-| <a name="module_synthetic_monitoring_jobs"></a> [synthetic\_monitoring\_jobs](#module\_synthetic\_monitoring\_jobs) | git::https://github.com/pagopa/terraform-azurerm-v4.git//monitoring_function | synthetic-improvements |
-| <a name="module_synthetic_snet"></a> [synthetic\_snet](#module\_synthetic\_snet) | git::https://github.com/pagopa/terraform-azurerm-v4.git//subnet | synthetic-improvements |
+| <a name="module_container_app_private_endpoint_snet"></a> [container\_app\_private\_endpoint\_snet](#module\_container\_app\_private\_endpoint\_snet) | git::https://github.com/pagopa/terraform-azurerm-v4.git//subnet | v1.20.0 |
+| <a name="module_storage_private_endpoint_snet"></a> [storage\_private\_endpoint\_snet](#module\_storage\_private\_endpoint\_snet) | git::https://github.com/pagopa/terraform-azurerm-v4.git//subnet | v1.20.0 |
+| <a name="module_synthetic_monitoring_jobs"></a> [synthetic\_monitoring\_jobs](#module\_synthetic\_monitoring\_jobs) | git::https://github.com/pagopa/terraform-azurerm-v4.git//monitoring_function | v1.20.0 |
+| <a name="module_synthetic_snet"></a> [synthetic\_snet](#module\_synthetic\_snet) | git::https://github.com/pagopa/terraform-azurerm-v4.git//subnet | v1.20.0 |
 
 ## Resources
 
@@ -31,14 +31,20 @@
 |------|------|
 | [azurerm_application_insights.monitoring_application_insights](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_container_app_environment.synthetic_cae](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_app_environment) | resource |
+| [azurerm_dashboard_grafana.grafana_dashboard](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dashboard_grafana) | resource |
 | [azurerm_log_analytics_workspace.monitoring_log_analytics_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_monitor_action_group.cstar_status](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_private_endpoint.private_endpoint_container_app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.monitoring_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.synthetic_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.grafana_dashboard_monitoring_admins](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.grafana_dashboard_monitoring_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.grafana_dashboard_monitoring_reader_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_key_vault.cicd_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+| [azurerm_key_vault.core_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault_secret.email_google_cstar_status](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.email_slack_cstar_status](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_private_dns_zone.storage_account_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
@@ -53,6 +59,7 @@
 | <a name="input_cidr_subnet_storage_private_endpoints"></a> [cidr\_subnet\_storage\_private\_endpoints](#input\_cidr\_subnet\_storage\_private\_endpoints) | Address prefixes subnet for storage private endpoints | `list(string)` | n/a | yes |
 | <a name="input_cidr_subnet_synthetic_cae"></a> [cidr\_subnet\_synthetic\_cae](#input\_cidr\_subnet\_synthetic\_cae) | Address prefixes subnet synthetic | `list(string)` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | n/a | yes |
+| <a name="input_enable_auto_dashboard_grafana"></a> [enable\_auto\_dashboard\_grafana](#input\_enable\_auto\_dashboard\_grafana) | (Optional) Enables the auto dashboard for grafana | `bool` | `false` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment | `string` | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |

--- a/src/40_platform/README.md
+++ b/src/40_platform/README.md
@@ -59,7 +59,6 @@
 | <a name="input_cidr_subnet_storage_private_endpoints"></a> [cidr\_subnet\_storage\_private\_endpoints](#input\_cidr\_subnet\_storage\_private\_endpoints) | Address prefixes subnet for storage private endpoints | `list(string)` | n/a | yes |
 | <a name="input_cidr_subnet_synthetic_cae"></a> [cidr\_subnet\_synthetic\_cae](#input\_cidr\_subnet\_synthetic\_cae) | Address prefixes subnet synthetic | `list(string)` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | n/a | yes |
-| <a name="input_enable_auto_dashboard_grafana"></a> [enable\_auto\_dashboard\_grafana](#input\_enable\_auto\_dashboard\_grafana) | (Optional) Enables the auto dashboard for grafana | `bool` | `false` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment | `string` | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |


### PR DESCRIPTION
### List of changes

- Added a new managed Grafana dashboard resource.
- Assigned associated IAM roles for user and admin access.
- Updated module references for synthetic monitoring and subnets to version `v1.20.0` of the Terraform module to ensure compatibility.

### Motivation and context

This update introduces a managed Grafana dashboard for improved monitoring and visibility. The module updates align with recent infrastructure standards and enhance compatibility across resources.

### Type of changes

- [x] Add new resources  
- [x] Update configuration to existing resources  

### Env to apply

- [x] DEV  
- [x] UAT  
- [x] PROD  

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change  
- [x] No  

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes  
- [x] No  

### Other information

N/A