### PR TITLE
feat: [PAYMCLOUD-334] Refactor peering modules and add VNet peering for CSTAR WEU

### DIFF
--- a/src/10_networking/00_data.tf
+++ b/src/10_networking/00_data.tf
@@ -11,3 +11,13 @@
 #   type          = "Microsoft.Network/privateDnsZones"
 #   required_tags = local.tags_for_private_dns
 # }
+
+data "azurerm_virtual_network" "vnet_weu_core" {
+  name                = local.vnet_weu_core.name
+  resource_group_name = local.vnet_weu_core.resource_group
+}
+
+data "azurerm_virtual_network" "vnet_weu_aks" {
+  name                = local.vnet_weu_aks.name
+  resource_group_name = local.vnet_weu_aks.resource_group
+}

--- a/src/10_networking/10_vnet.tf
+++ b/src/10_networking/10_vnet.tf
@@ -8,6 +8,10 @@ resource "azurerm_resource_group" "rg_network" {
 #
 # Vnet
 #
+# NOTE: DDoS protection in prod is automatically enforced via organization policy.
+# This module does not manage ddos_protection_plan to avoid conflicts.
+# Expect Terraform to try removing it, but the policy will re-apply it.
+# No action needed unless the module is updated to support ignore_changes.
 
 module "vnet_core_hub" {
   source = "./.terraform/modules/__v4__/virtual_network"

--- a/src/10_networking/12_peering.tf
+++ b/src/10_networking/12_peering.tf
@@ -32,7 +32,7 @@ locals {
 # ⛓️ Peering to cstar-infrastructure
 #
 # SECURE-HUB TO CSTAR WEU CORE
-module "vnet_spoke_to_core_peering" {
+module "vnet_secure_hub_to_core_peering" {
   source = "./.terraform/modules/__v4__/virtual_network_peering"
 
   for_each = local.secure_hub_vnets_peered
@@ -42,17 +42,17 @@ module "vnet_spoke_to_core_peering" {
   source_resource_group_name       = each.value.resource_group_name
   source_virtual_network_name      = each.value.name
   source_remote_virtual_network_id = each.value.id
-  source_allow_gateway_transit     = true
+  source_use_remote_gateways       = true
 
   # Define target virtual network peering details
   target_resource_group_name       = data.azurerm_virtual_network.vnet_weu_core.resource_group_name
   target_virtual_network_name      = data.azurerm_virtual_network.vnet_weu_core.name
   target_remote_virtual_network_id = data.azurerm_virtual_network.vnet_weu_core.id
-  target_use_remote_gateways       = true
+  target_allow_gateway_transit     = true
 }
 
 # SECURE-HUB TO CSTAR WEU AKS
-module "vnet_spoke_to_aks_peering" {
+module "vnet_secure_hub_to_aks_peering" {
   source = "./.terraform/modules/__v4__/virtual_network_peering"
 
   for_each = local.secure_hub_vnets_peered
@@ -61,11 +61,9 @@ module "vnet_spoke_to_aks_peering" {
   source_resource_group_name       = each.value.resource_group_name
   source_virtual_network_name      = each.value.name
   source_remote_virtual_network_id = each.value.id
-  source_allow_gateway_transit     = true
 
   # Define target virtual network peering details
   target_resource_group_name       = data.azurerm_virtual_network.vnet_weu_aks.resource_group_name
   target_virtual_network_name      = data.azurerm_virtual_network.vnet_weu_aks.name
   target_remote_virtual_network_id = data.azurerm_virtual_network.vnet_weu_aks.id
-  target_use_remote_gateways       = true
 }

--- a/src/10_networking/12_peering.tf
+++ b/src/10_networking/12_peering.tf
@@ -1,0 +1,71 @@
+locals {
+  secure_hub_vnets_peered = {
+    hub = {
+      name                = module.vnet_core_hub.name
+      id                  = module.vnet_core_hub.id
+      resource_group_name = azurerm_resource_group.rg_network.name
+    }
+    platform = {
+      name                = module.vnet_spoke_platform_core.name
+      id                  = module.vnet_spoke_platform_core.id
+      resource_group_name = azurerm_resource_group.rg_network.name
+    }
+    data = {
+      name                = module.vnet_spoke_data.name
+      id                  = module.vnet_spoke_data.id
+      resource_group_name = azurerm_resource_group.rg_network.name
+    }
+    compute = {
+      name                = module.vnet_spoke_compute.name
+      id                  = module.vnet_spoke_compute.id
+      resource_group_name = azurerm_resource_group.rg_network.name
+    }
+    security = {
+      name                = module.vnet_spoke_security.name
+      id                  = module.vnet_spoke_security.id
+      resource_group_name = azurerm_resource_group.rg_network.name
+    }
+  }
+}
+
+#
+# ⛓️ Peering to cstar-infrastructure
+#
+# SECURE-HUB TO CSTAR WEU CORE
+module "vnet_spoke_to_core_peering" {
+  source = "./.terraform/modules/__v4__/virtual_network_peering"
+
+  for_each = local.secure_hub_vnets_peered
+
+
+  # Define source virtual network peering details
+  source_resource_group_name       = each.value.resource_group_name
+  source_virtual_network_name      = each.value.name
+  source_remote_virtual_network_id = each.value.id
+  source_allow_gateway_transit     = true
+
+  # Define target virtual network peering details
+  target_resource_group_name       = data.azurerm_virtual_network.vnet_weu_core.resource_group_name
+  target_virtual_network_name      = data.azurerm_virtual_network.vnet_weu_core.name
+  target_remote_virtual_network_id = data.azurerm_virtual_network.vnet_weu_core.id
+  target_use_remote_gateways       = true
+}
+
+# SECURE-HUB TO CSTAR WEU AKS
+module "vnet_spoke_to_aks_peering" {
+  source = "./.terraform/modules/__v4__/virtual_network_peering"
+
+  for_each = local.secure_hub_vnets_peered
+
+  # Define source virtual network peering details
+  source_resource_group_name       = each.value.resource_group_name
+  source_virtual_network_name      = each.value.name
+  source_remote_virtual_network_id = each.value.id
+  source_allow_gateway_transit     = true
+
+  # Define target virtual network peering details
+  target_resource_group_name       = data.azurerm_virtual_network.vnet_weu_aks.resource_group_name
+  target_virtual_network_name      = data.azurerm_virtual_network.vnet_weu_aks.name
+  target_remote_virtual_network_id = data.azurerm_virtual_network.vnet_weu_aks.id
+  target_use_remote_gateways       = true
+}

--- a/src/10_networking/99_locals.tf
+++ b/src/10_networking/99_locals.tf
@@ -10,6 +10,16 @@ locals {
     "domain" = "mc"
   })
 
+  vnet_weu_core = {
+    name           = "${var.prefix}-${var.env_short}-vnet"
+    resource_group = "${var.prefix}-${var.env_short}-vnet-rg"
+  }
+
+  vnet_weu_aks = {
+    name           = "${var.prefix}-${var.env_short}-weu-${var.env}01-vnet"
+    resource_group = "${var.prefix}-${var.env_short}-weu-${var.env}01-vnet-rg"
+  }
+
   # # Dns Forwarder
   # dns_forwarder_vm_image_name = "${local.product_nodomain}-packer-dns-forwarder-ubuntu2204-image-${var.dns_forwarder_vm_image_version}"
 }

--- a/src/10_networking/README.md
+++ b/src/10_networking/README.md
@@ -25,6 +25,8 @@
 | <a name="module_vnet_spoke_data"></a> [vnet\_spoke\_data](#module\_vnet\_spoke\_data) | ./.terraform/modules/__v4__/virtual_network | n/a |
 | <a name="module_vnet_spoke_platform_core"></a> [vnet\_spoke\_platform\_core](#module\_vnet\_spoke\_platform\_core) | ./.terraform/modules/__v4__/virtual_network | n/a |
 | <a name="module_vnet_spoke_security"></a> [vnet\_spoke\_security](#module\_vnet\_spoke\_security) | ./.terraform/modules/__v4__/virtual_network | n/a |
+| <a name="module_vnet_spoke_to_aks_peering"></a> [vnet\_spoke\_to\_aks\_peering](#module\_vnet\_spoke\_to\_aks\_peering) | ./.terraform/modules/__v4__/virtual_network_peering | n/a |
+| <a name="module_vnet_spoke_to_core_peering"></a> [vnet\_spoke\_to\_core\_peering](#module\_vnet\_spoke\_to\_core\_peering) | ./.terraform/modules/__v4__/virtual_network_peering | n/a |
 
 ## Resources
 
@@ -34,6 +36,8 @@
 | [azurerm_resource_group.rg_network](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+| [azurerm_virtual_network.vnet_weu_aks](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
+| [azurerm_virtual_network.vnet_weu_core](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
 ## Inputs
 

--- a/src/10_networking/README.md
+++ b/src/10_networking/README.md
@@ -21,12 +21,12 @@
 | <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | 77d05f98b95c544b4997f02cb94fd53bd4c57eee |
 | <a name="module_azdoa_snet"></a> [azdoa\_snet](#module\_azdoa\_snet) | ./.terraform/modules/__v4__/subnet | n/a |
 | <a name="module_vnet_core_hub"></a> [vnet\_core\_hub](#module\_vnet\_core\_hub) | ./.terraform/modules/__v4__/virtual_network | n/a |
+| <a name="module_vnet_secure_hub_to_aks_peering"></a> [vnet\_secure\_hub\_to\_aks\_peering](#module\_vnet\_secure\_hub\_to\_aks\_peering) | ./.terraform/modules/__v4__/virtual_network_peering | n/a |
+| <a name="module_vnet_secure_hub_to_core_peering"></a> [vnet\_secure\_hub\_to\_core\_peering](#module\_vnet\_secure\_hub\_to\_core\_peering) | ./.terraform/modules/__v4__/virtual_network_peering | n/a |
 | <a name="module_vnet_spoke_compute"></a> [vnet\_spoke\_compute](#module\_vnet\_spoke\_compute) | ./.terraform/modules/__v4__/virtual_network | n/a |
 | <a name="module_vnet_spoke_data"></a> [vnet\_spoke\_data](#module\_vnet\_spoke\_data) | ./.terraform/modules/__v4__/virtual_network | n/a |
 | <a name="module_vnet_spoke_platform_core"></a> [vnet\_spoke\_platform\_core](#module\_vnet\_spoke\_platform\_core) | ./.terraform/modules/__v4__/virtual_network | n/a |
 | <a name="module_vnet_spoke_security"></a> [vnet\_spoke\_security](#module\_vnet\_spoke\_security) | ./.terraform/modules/__v4__/virtual_network | n/a |
-| <a name="module_vnet_spoke_to_aks_peering"></a> [vnet\_spoke\_to\_aks\_peering](#module\_vnet\_spoke\_to\_aks\_peering) | ./.terraform/modules/__v4__/virtual_network_peering | n/a |
-| <a name="module_vnet_spoke_to_core_peering"></a> [vnet\_spoke\_to\_core\_peering](#module\_vnet\_spoke\_to\_core\_peering) | ./.terraform/modules/__v4__/virtual_network_peering | n/a |
 
 ## Resources
 

--- a/src/10_networking/env/itn-uat/terraform.tfvars
+++ b/src/10_networking/env/itn-uat/terraform.tfvars
@@ -13,6 +13,8 @@ tags = {
   CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
 }
 
+nat_idle_timeout_in_minutes = 4
+
 #
 # VNET
 #


### PR DESCRIPTION
### List of changes

- Renamed peering module identifiers for better clarity.
- Switched transit settings to enable remote gateway usage.
- Added NAT idle timeout configuration in ITN-UAT environment variables.
- Introduced a clarifying comment on DDoS protection enforcement.
- Added VNet peering for secure hub VNets with CSTAR WEU core/AKS VNets.
- Created supporting data and local variables for VNet configurations.

### Motivation and context

This pull request improves clarity in peering module identifiers and optimizes settings for remote gateway transit. It also addresses potential misunderstandings through comments and formalizes NAT timeout settings. Additionally, it sets up VNet peering with necessary configurations to enhance connectivity and transit capability in the CSTAR WEU region.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

This PR enhances clarity, ensures configuration correctness, and supports better VNet integration for CSTAR WEU networks.