### PR TITLE
feat: [PAYMCLOUD-311] Add conditional Opsgenie action group for production

### DIFF
--- a/src/40_platform/00_data.tf
+++ b/src/40_platform/00_data.tf
@@ -46,3 +46,9 @@ data "azurerm_key_vault_secret" "email_slack_cstar_status" {
   name         = "email-slack-cstar-status"
   key_vault_id = data.azurerm_key_vault.cicd_kv.id
 }
+
+data "azurerm_monitor_action_group" "infra_opsgenie" {
+  count               = var.env_short == "p" ? 1 : 0
+  resource_group_name = "${local.product}-monitor-rg"
+  name                = "CstarInfraOpsgenie"
+}

--- a/src/40_platform/20_synthetic.tf
+++ b/src/40_platform/20_synthetic.tf
@@ -66,7 +66,7 @@ module "synthetic_monitoring_jobs" {
 
   application_insight_name              = azurerm_application_insights.monitoring_application_insights.name
   application_insight_rg_name           = azurerm_application_insights.monitoring_application_insights.resource_group_name
-  application_insights_action_group_ids = [azurerm_monitor_action_group.cstar_status.id]
+  application_insights_action_group_ids = var.env_short == "p" ? [data.azurerm_monitor_action_group.infra_opsgenie[0].id] : [azurerm_monitor_action_group.cstar_status.id]
 
   job_settings = {
     container_app_environment_id = azurerm_container_app_environment.synthetic_cae.id

--- a/src/40_platform/README.md
+++ b/src/40_platform/README.md
@@ -49,6 +49,7 @@
 | [azurerm_key_vault.core_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault_secret.email_google_cstar_status](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.email_slack_cstar_status](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_monitor_action_group.infra_opsgenie](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_private_dns_zone.storage_account_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 | [azurerm_virtual_network.vnet_platform](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |


### PR DESCRIPTION
### List of changes

- Introduced a production-specific Opsgenie action group to the synthetic monitoring setup.
- Maintained existing configurations for non-production environments.

### Motivation and context

This change ensures that alerts are routed correctly in production environments, thereby improving monitoring efficiency and reducing misdirected alerts.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

N/A

---

### If PR is partially applied, why? (reserved to mantainers)

N/A