### PR TITLE
fix: [PAYMCLOUD-311] Refactor OpsGenie action group data organization

### DIFF
--- a/src/40_platform/00_data.tf
+++ b/src/40_platform/00_data.tf
@@ -46,9 +46,3 @@ data "azurerm_key_vault_secret" "email_slack_cstar_status" {
   name         = "email-slack-cstar-status"
   key_vault_id = data.azurerm_key_vault.cicd_kv.id
 }
-
-data "azurerm_monitor_action_group" "infra_opsgenie" {
-  count               = var.env_short == "p" ? 1 : 0
-  resource_group_name = "${local.product}-monitor-rg"
-  name                = "CstarInfraOpsgenie"
-}

--- a/src/40_platform/11_monitoring.tf
+++ b/src/40_platform/11_monitoring.tf
@@ -55,3 +55,9 @@ resource "azurerm_monitor_action_group" "cstar_status" {
 
   tags = var.tags
 }
+
+data "azurerm_monitor_action_group" "infra_opsgenie" {
+  count               = var.env_short == "p" ? 1 : 0
+  resource_group_name = "${local.product}-monitor-rg"
+  name                = "CstarInfraOpsgenie"
+}

--- a/src/40_platform/20_synthetic.tf
+++ b/src/40_platform/20_synthetic.tf
@@ -64,9 +64,17 @@ module "synthetic_monitoring_jobs" {
   prefix              = "${local.product}-${var.location_short}"
   resource_group_name = azurerm_resource_group.synthetic_rg.name
 
-  application_insight_name              = azurerm_application_insights.monitoring_application_insights.name
-  application_insight_rg_name           = azurerm_application_insights.monitoring_application_insights.resource_group_name
-  application_insights_action_group_ids = var.env_short == "p" ? [data.azurerm_monitor_action_group.infra_opsgenie[0].id] : [azurerm_monitor_action_group.cstar_status.id]
+  application_insight_name    = azurerm_application_insights.monitoring_application_insights.name
+  application_insight_rg_name = azurerm_application_insights.monitoring_application_insights.resource_group_name
+  application_insights_action_group_ids = flatten([
+    [
+      azurerm_monitor_action_group.cstar_status.id,
+    ],
+    (var.env == "prod" ? [
+      azurerm_monitor_action_group.cstar_status.id,
+      data.azurerm_monitor_action_group.infra_opsgenie[0].id
+    ] : [])
+  ])
 
   job_settings = {
     container_app_environment_id = azurerm_container_app_environment.synthetic_cae.id


### PR DESCRIPTION
### List of changes

- Moved `azurerm_monitor_action_group` definition for `infra_opsgenie` from `00_data.tf` to `11_monitoring.tf`.
- Adjusted references and logic in `20_synthetic.tf` to handle action group IDs correctly based on the environment.

### Motivation and context

These changes improve the organization of the Terraform codebase by placing the `azurerm_monitor_action_group` definition in a more relevant file, enhancing readability and maintainability. Adjustments to references ensure continued operational integrity.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

N/A

--- 

### If PR is partially applied, why? (reserved to mantainers)

N/A