### PR TITLE
feat: [EBE-34] update keycloak configuration to expose api on public internet

### DIFF
--- a/src/41_platform_coder/22_keycloak_v2.tf
+++ b/src/41_platform_coder/22_keycloak_v2.tf
@@ -91,6 +91,7 @@ resource "helm_release" "keycloak" {
       keycloak_admin_username     = azurerm_key_vault_secret.keycloak_admin_username.value
       keycloak_ingress_hostname   = local.keycloak_ingress_hostname
       ingress_tls_secret_name     = replace(local.keycloak_ingress_hostname, ".", "-")
+      keycloak_external_hostname  = local.keycloak_external_hostname
       replica_count_min           = var.keycloak_configuration.replica_count_min
       replica_count_max           = var.keycloak_configuration.replica_count_max
       realm_admin_import_filename = "admin_realm.json"

--- a/src/41_platform_coder/99_locals.tf
+++ b/src/41_platform_coder/99_locals.tf
@@ -29,8 +29,9 @@ locals {
   app_insights_name  = "${local.project}-monitoring-appinsights"
 
   # Keycloak
-  keycloak_db_name          = "bitnami_keycloak"
-  keycloak_ingress_hostname = "keycloak.itn.internal.dev.cstar.pagopa.it"
+  keycloak_db_name           = "bitnami_keycloak"
+  keycloak_ingress_hostname  = "keycloak.${var.location_short}.${var.dns_zone_internal_prefix}.${var.prefix}.${var.external_domain}"
+  keycloak_external_hostname = "https://${var.mcshared_dns_zone_prefix}.${var.prefix}.${var.external_domain}/auth-itn"
 
   #
   # AKS

--- a/src/41_platform_coder/99_variables.tf
+++ b/src/41_platform_coder/99_variables.tf
@@ -68,6 +68,12 @@ variable "external_domain" {
   description = "Domain for delegation"
 }
 
+variable "mcshared_dns_zone_prefix" {
+  type        = string
+  default     = null
+  description = "The dns subdomain for mcshared"
+}
+
 #
 # Kubernetes
 #

--- a/src/41_platform_coder/README.md
+++ b/src/41_platform_coder/README.md
@@ -83,6 +83,7 @@
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
 | <a name="input_location_display_name"></a> [location\_display\_name](#input\_location\_display\_name) | Location short like eg: neu, weu.. | `string` | n/a | yes |
 | <a name="input_location_short"></a> [location\_short](#input\_location\_short) | Location short like eg: neu, weu.. | `string` | n/a | yes |
+| <a name="input_mcshared_dns_zone_prefix"></a> [mcshared\_dns\_zone\_prefix](#input\_mcshared\_dns\_zone\_prefix) | The dns subdomain for mcshared | `string` | `null` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | <pre>{<br/>  "CreatedBy": "Terraform"<br/>}</pre> | no |
 

--- a/src/41_platform_coder/env/itn-dev/terraform.tfvars
+++ b/src/41_platform_coder/env/itn-dev/terraform.tfvars
@@ -19,6 +19,7 @@ tags = {
 #
 dns_zone_internal_prefix = "internal.dev"
 external_domain          = "pagopa.it"
+mcshared_dns_zone_prefix = "api-mcshared.dev"
 
 ## Postgres
 keycloak_pgflex_params = {

--- a/src/41_platform_coder/env/itn-prod/terraform.tfvars
+++ b/src/41_platform_coder/env/itn-prod/terraform.tfvars
@@ -14,6 +14,13 @@ tags = {
   CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
 }
 
+#
+# Dns
+#
+dns_zone_internal_prefix = "internal"
+external_domain          = "pagopa.it"
+mcshared_dns_zone_prefix = "api-mcshared"
+
 ## Postgres
 keycloak_pgflex_params = {
   sku_name   = "B_Standard_B2s"

--- a/src/41_platform_coder/env/itn-uat/terraform.tfvars
+++ b/src/41_platform_coder/env/itn-uat/terraform.tfvars
@@ -14,6 +14,13 @@ tags = {
   CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
 }
 
+#
+# Dns
+#
+dns_zone_internal_prefix = "internal.uat"
+external_domain          = "pagopa.it"
+mcshared_dns_zone_prefix = "api-mcshared.uat"
+
 ## Postgres
 keycloak_pgflex_params = {
   sku_name   = "B_Standard_B2s"

--- a/src/41_platform_coder/k8s/keycloak/values.yaml.tpl
+++ b/src/41_platform_coder/k8s/keycloak/values.yaml.tpl
@@ -1,5 +1,8 @@
 forceDeployVersion: ${force_deploy_version}
 
+production: true
+proxy: "edge"
+
 auth:
   adminUser: "${keycloak_admin_username}"
   existingSecret: "keycloak-admin-secret" #keycloak admin password is in this secret
@@ -30,6 +33,12 @@ extraEnvVars:
     value: "sslmode=require"
   - name: KEYCLOAK_IMPORT
     value: /opt/bitnami/keycloak/data/import/${realm_admin_import_filename}
+  - name: KEYCLOAK_HOSTNAME
+    value: ${keycloak_external_hostname}
+  - name: KEYCLOAK_HOSTNAME_BACKCHANNEL_DYNAMIC
+    value: "true"
+  - name: KEYCLOAK_HOSTNAME_ADMIN
+    value: "https://${keycloak_ingress_hostname}"
 
 extraVolumes:
   - name: realm-import


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to configure keycloak to expose its API on APIM. 
The admin console must remain accessible through VPN on private ingress url.
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
