### PR TITLE
feat: [IDP-2767] Deploy IDP platform with postgresql IDH migration with right RG

### DIFF
--- a/src/41_platform_coder/.terraform.lock.hcl
+++ b/src/41_platform_coder/.terraform.lock.hcl
@@ -43,7 +43,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
 
 provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.17.0"
-  constraints = "~> 2.0"
+  constraints = "~> 2.0, ~> 2.12"
   hashes = [
     "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
     "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
@@ -62,22 +62,22 @@ provider "registry.terraform.io/hashicorp/helm" {
 }
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
-  version     = "2.37.1"
-  constraints = "~> 2.0"
+  version     = "2.38.0"
+  constraints = "~> 2.0, ~> 2.30"
   hashes = [
-    "h1:+37jC6JlkPyPvDHudK3qaj7ZVJ0Zy9zc9+oq8h1WayA=",
-    "zh:0ed097413c7fc804479e325966886b405dc0b75ad2b4f54ce4df1d8e4802b397",
-    "zh:17dcf4a685a00d2d048671124e8a1a8e836b58ecd2ef628a1c666fe0ced2e598",
-    "zh:36891284e5bced57c438f12d0b27856b0d4b70b562bd200b01919a6a89545be9",
-    "zh:3e49d86b508e641ba122d1b0af24cdc4d8ffa2ec1b30022436fb1d7c6ba696ea",
-    "zh:40be623e116708bdcb0fac32989db43720f031c5fe9a4dc63395078185d24403",
-    "zh:44fc0ac3bc39e289b67f9dde7ee9fef29eb8192197e5e68fee69098573021722",
-    "zh:957aa451573bcde5d57f6f8338ea3139010c7f61fefe8f6a140a8c267f056511",
-    "zh:c55fd85b7e8acaac17e30670ac3574b88b3530820dd004bcd2a5daa8624a46e9",
-    "zh:c743f06843a1f5ecde2b8ef639f4d3db654a334ef248dee57261c719ea843f3a",
-    "zh:c93cc71c64b838d89522ac5fb60f68e0e1e7f2fc39db6b0ead7afd78795e79ed",
-    "zh:eda1163c2266905adc54bc78cc3e7b606a164fbc6b59be607db933b302015ccd",
+    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
   ]
 }
 

--- a/src/41_platform_coder/00_data.tf
+++ b/src/41_platform_coder/00_data.tf
@@ -1,5 +1,5 @@
 data "azurerm_resource_group" "platform_data" {
-  name = local.kv_core_resource_group_name
+  name = local.platform_data_rg_name
 }
 
 #------------------------------------------------

--- a/src/41_platform_coder/20_keycloak_postgres.tf
+++ b/src/41_platform_coder/20_keycloak_postgres.tf
@@ -60,6 +60,7 @@ module "keycloak_pgflex" {
   log_analytics_workspace_id  = data.azurerm_log_analytics_workspace.logs_workspace.id
   private_dns_registration    = false
   pg_bouncer_enabled          = var.keycloak_pgflex_params.pgres_flex_pgbouncer_enabled
+  zone                        = var.keycloak_pgflex_params.zone
 
   # Geo-replication configuration for disaster recovery
   geo_replication = {

--- a/src/41_platform_coder/99_main.tf
+++ b/src/41_platform_coder/99_main.tf
@@ -40,8 +40,8 @@ data "azurerm_subscription" "current" {}
 data "azurerm_client_config" "current" {}
 
 module "__v4__" {
-  # https://github.com/pagopa/terraform-azurerm-v4/releases/tag/v7.22.0
-  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git?ref=70cf66cc338d8c13ed5a831ddcd54b8ea26a4ac0"
+  # https://github.com/pagopa/terraform-azurerm-v4/releases/tag/v7.26.0
+  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git?ref=ac214b087ff30caa40cd505d30c4a783bc81efe0"
 }
 
 provider "kubernetes" {

--- a/src/41_platform_coder/99_main.tf
+++ b/src/41_platform_coder/99_main.tf
@@ -40,8 +40,8 @@ data "azurerm_subscription" "current" {}
 data "azurerm_client_config" "current" {}
 
 module "__v4__" {
-  # https://github.com/pagopa/terraform-azurerm-v4/releases/tag/v7.2.0
-  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git?ref=5c38b6fc6e2aa2c2c3e94be5dd6bb6ee8d690a49"
+  # https://github.com/pagopa/terraform-azurerm-v4/releases/tag/v7.22.0
+  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git?ref=70cf66cc338d8c13ed5a831ddcd54b8ea26a4ac0"
 }
 
 provider "kubernetes" {

--- a/src/41_platform_coder/99_variables.tf
+++ b/src/41_platform_coder/99_variables.tf
@@ -88,6 +88,7 @@ variable "k8s_kube_config_path_prefix" {
 variable "keycloak_pgflex_params" {
   type = object({
     enabled                                = bool
+    zone                                   = number
     idh_resource_tier                      = string
     geo_replication_enabled                = bool
     pgres_flex_pgbouncer_enabled           = bool

--- a/src/41_platform_coder/99_variables.tf
+++ b/src/41_platform_coder/99_variables.tf
@@ -59,7 +59,7 @@ variable "domain" {
 #
 variable "dns_zone_internal_prefix" {
   type        = string
-  default     = null
+  default     = ""
   description = "The dns subdomain."
 }
 
@@ -88,21 +88,10 @@ variable "k8s_kube_config_path_prefix" {
 variable "keycloak_pgflex_params" {
   type = object({
     enabled                                = bool
-    sku_name                               = string
-    db_version                             = string
-    storage_mb                             = string
-    zone                                   = number
-    standby_zone                           = optional(number, 1)
-    backup_retention_days                  = number
-    geo_redundant_backup_enabled           = bool
-    create_mode                            = string
-    pgres_flex_private_endpoint_enabled    = bool
-    pgres_flex_ha_enabled                  = bool
+    idh_resource_tier                      = string
+    geo_replication_enabled                = bool
     pgres_flex_pgbouncer_enabled           = bool
     pgres_flex_diagnostic_settings_enabled = bool
-    max_connections                        = number
-    pgbouncer_min_pool_size                = number
-    pgbouncer_default_pool_size            = number
   })
 }
 

--- a/src/41_platform_coder/README.md
+++ b/src/41_platform_coder/README.md
@@ -18,16 +18,16 @@
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.4.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.32.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.17.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.37.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.38.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | 5c38b6fc6e2aa2c2c3e94be5dd6bb6ee8d690a49 |
+| <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | 70cf66cc338d8c13ed5a831ddcd54b8ea26a4ac0 |
 | <a name="module_cert_mounter"></a> [cert\_mounter](#module\_cert\_mounter) | ./.terraform/modules/__v4__/cert_mounter | n/a |
-| <a name="module_keycloak_pgflex"></a> [keycloak\_pgflex](#module\_keycloak\_pgflex) | ./.terraform/modules/__v4__/postgres_flexible_server | n/a |
+| <a name="module_keycloak_pgflex"></a> [keycloak\_pgflex](#module\_keycloak\_pgflex) | ./.terraform/modules/__v4__/IDH/postgres_flexible_server | n/a |
 | <a name="module_tag_config"></a> [tag\_config](#module\_tag\_config) | ../tag_config | n/a |
 | <a name="module_workload_identity_configuration_platform_coder_keycloak"></a> [workload\_identity\_configuration\_platform\_coder\_keycloak](#module\_workload\_identity\_configuration\_platform\_coder\_keycloak) | ./.terraform/modules/__v4__/kubernetes_workload_identity_configuration | n/a |
 | <a name="module_workload_identity_platform_coder"></a> [workload\_identity\_platform\_coder](#module\_workload\_identity\_platform\_coder) | ./.terraform/modules/__v4__/kubernetes_workload_identity_init | n/a |
@@ -74,14 +74,14 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_dns_zone_internal_prefix"></a> [dns\_zone\_internal\_prefix](#input\_dns\_zone\_internal\_prefix) | The dns subdomain. | `string` | `null` | no |
+| <a name="input_dns_zone_internal_prefix"></a> [dns\_zone\_internal\_prefix](#input\_dns\_zone\_internal\_prefix) | The dns subdomain. | `string` | `""` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | n/a | yes |
 | <a name="input_env"></a> [env](#input\_env) | Environment | `string` | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain"></a> [external\_domain](#input\_external\_domain) | Domain for delegation | `string` | n/a | yes |
 | <a name="input_k8s_kube_config_path_prefix"></a> [k8s\_kube\_config\_path\_prefix](#input\_k8s\_kube\_config\_path\_prefix) | Kubernetes | `string` | `"~/.kube"` | no |
 | <a name="input_keycloak_configuration"></a> [keycloak\_configuration](#input\_keycloak\_configuration) | n/a | <pre>object({<br/>    replica_count_min = number<br/>    replica_count_max = number<br/>  })</pre> | n/a | yes |
-| <a name="input_keycloak_pgflex_params"></a> [keycloak\_pgflex\_params](#input\_keycloak\_pgflex\_params) | Postgres Flexible | <pre>object({<br/>    enabled                                = bool<br/>    sku_name                               = string<br/>    db_version                             = string<br/>    storage_mb                             = string<br/>    zone                                   = number<br/>    standby_zone                           = optional(number, 1)<br/>    backup_retention_days                  = number<br/>    geo_redundant_backup_enabled           = bool<br/>    create_mode                            = string<br/>    pgres_flex_private_endpoint_enabled    = bool<br/>    pgres_flex_ha_enabled                  = bool<br/>    pgres_flex_pgbouncer_enabled           = bool<br/>    pgres_flex_diagnostic_settings_enabled = bool<br/>    max_connections                        = number<br/>    pgbouncer_min_pool_size                = number<br/>    pgbouncer_default_pool_size            = number<br/>  })</pre> | n/a | yes |
+| <a name="input_keycloak_pgflex_params"></a> [keycloak\_pgflex\_params](#input\_keycloak\_pgflex\_params) | Postgres Flexible | <pre>object({<br/>    enabled                                = bool<br/>    idh_resource_tier                      = string<br/>    geo_replication_enabled                = bool<br/>    pgres_flex_pgbouncer_enabled           = bool<br/>    pgres_flex_diagnostic_settings_enabled = bool<br/>  })</pre> | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
 | <a name="input_location_display_name"></a> [location\_display\_name](#input\_location\_display\_name) | Location short like eg: neu, weu.. | `string` | n/a | yes |
 | <a name="input_location_short"></a> [location\_short](#input\_location\_short) | Location short like eg: neu, weu.. | `string` | n/a | yes |

--- a/src/41_platform_coder/README.md
+++ b/src/41_platform_coder/README.md
@@ -25,7 +25,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | 70cf66cc338d8c13ed5a831ddcd54b8ea26a4ac0 |
+| <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | ac214b087ff30caa40cd505d30c4a783bc81efe0 |
 | <a name="module_cert_mounter"></a> [cert\_mounter](#module\_cert\_mounter) | ./.terraform/modules/__v4__/cert_mounter | n/a |
 | <a name="module_keycloak_pgflex"></a> [keycloak\_pgflex](#module\_keycloak\_pgflex) | ./.terraform/modules/__v4__/IDH/postgres_flexible_server | n/a |
 | <a name="module_tag_config"></a> [tag\_config](#module\_tag\_config) | ../tag_config | n/a |
@@ -81,7 +81,7 @@
 | <a name="input_external_domain"></a> [external\_domain](#input\_external\_domain) | Domain for delegation | `string` | n/a | yes |
 | <a name="input_k8s_kube_config_path_prefix"></a> [k8s\_kube\_config\_path\_prefix](#input\_k8s\_kube\_config\_path\_prefix) | Kubernetes | `string` | `"~/.kube"` | no |
 | <a name="input_keycloak_configuration"></a> [keycloak\_configuration](#input\_keycloak\_configuration) | n/a | <pre>object({<br/>    replica_count_min = number<br/>    replica_count_max = number<br/>  })</pre> | n/a | yes |
-| <a name="input_keycloak_pgflex_params"></a> [keycloak\_pgflex\_params](#input\_keycloak\_pgflex\_params) | Postgres Flexible | <pre>object({<br/>    enabled                                = bool<br/>    idh_resource_tier                      = string<br/>    geo_replication_enabled                = bool<br/>    pgres_flex_pgbouncer_enabled           = bool<br/>    pgres_flex_diagnostic_settings_enabled = bool<br/>  })</pre> | n/a | yes |
+| <a name="input_keycloak_pgflex_params"></a> [keycloak\_pgflex\_params](#input\_keycloak\_pgflex\_params) | Postgres Flexible | <pre>object({<br/>    enabled                                = bool<br/>    zone                                   = number<br/>    idh_resource_tier                      = string<br/>    geo_replication_enabled                = bool<br/>    pgres_flex_pgbouncer_enabled           = bool<br/>    pgres_flex_diagnostic_settings_enabled = bool<br/>  })</pre> | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
 | <a name="input_location_display_name"></a> [location\_display\_name](#input\_location\_display\_name) | Location short like eg: neu, weu.. | `string` | n/a | yes |
 | <a name="input_location_short"></a> [location\_short](#input\_location\_short) | Location short like eg: neu, weu.. | `string` | n/a | yes |

--- a/src/41_platform_coder/env/itn-dev/terraform.tfvars
+++ b/src/41_platform_coder/env/itn-dev/terraform.tfvars
@@ -23,26 +23,14 @@ mcshared_dns_zone_prefix = "api-mcshared.dev"
 
 ## Postgres
 keycloak_pgflex_params = {
-  enabled    = true
-  sku_name   = "B_Standard_B2s"
-  db_version = "16"
-  # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
-  # 2097152, 4194304, 8388608, 16777216, and 33554432.
-  storage_mb                             = 32768
-  zone                                   = 1
-  backup_retention_days                  = 7
-  geo_redundant_backup_enabled           = false
-  create_mode                            = "Default"
-  pgres_flex_private_endpoint_enabled    = true
-  pgres_flex_ha_enabled                  = false
+  enabled                                = true
+  idh_resource_tier                      = "pg_burst_flex2"
+  geo_replication_enabled                = false
   pgres_flex_pgbouncer_enabled           = false
   pgres_flex_diagnostic_settings_enabled = false
-  max_connections                        = 1700
-  pgbouncer_min_pool_size                = 100
-  pgbouncer_default_pool_size            = 100
 }
 
 keycloak_configuration = {
-  replica_count_min = 1
-  replica_count_max = 2
+  replica_count_min = 2
+  replica_count_max = 3
 }

--- a/src/41_platform_coder/env/itn-dev/terraform.tfvars
+++ b/src/41_platform_coder/env/itn-dev/terraform.tfvars
@@ -26,6 +26,7 @@ keycloak_pgflex_params = {
   enabled                                = true
   idh_resource_tier                      = "pg_burst_flex2"
   geo_replication_enabled                = false
+  zone                                   = 2
   pgres_flex_pgbouncer_enabled           = false
   pgres_flex_diagnostic_settings_enabled = false
 }

--- a/src/41_platform_coder/env/itn-prod/terraform.tfvars
+++ b/src/41_platform_coder/env/itn-prod/terraform.tfvars
@@ -23,24 +23,11 @@ mcshared_dns_zone_prefix = "api-mcshared"
 
 ## Postgres
 keycloak_pgflex_params = {
-  enabled    = true
-  sku_name   = "GP_Standard_D4ds_v5"
-  db_version = "16"
-  # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
-  # 2097152, 4194304, 8388608, 16777216, and 33554432.
-  storage_mb                             = 32768
-  zone                                   = 1
-  standby_zone                           = 2
-  backup_retention_days                  = 30
-  geo_redundant_backup_enabled           = false
-  create_mode                            = "Default"
-  pgres_flex_private_endpoint_enabled    = true
-  pgres_flex_ha_enabled                  = true
+  enabled                                = true
+  idh_resource_tier                      = "pgflex2"
+  geo_replication_enabled                = false
   pgres_flex_pgbouncer_enabled           = false
   pgres_flex_diagnostic_settings_enabled = false
-  max_connections                        = 1700
-  pgbouncer_min_pool_size                = 100
-  pgbouncer_default_pool_size            = 100
 }
 
 keycloak_configuration = {

--- a/src/41_platform_coder/env/itn-prod/terraform.tfvars
+++ b/src/41_platform_coder/env/itn-prod/terraform.tfvars
@@ -26,6 +26,7 @@ keycloak_pgflex_params = {
   enabled                                = true
   idh_resource_tier                      = "pgflex2"
   geo_replication_enabled                = false
+  zone                                   = 1
   pgres_flex_pgbouncer_enabled           = false
   pgres_flex_diagnostic_settings_enabled = false
 }

--- a/src/41_platform_coder/env/itn-prod/terraform.tfvars
+++ b/src/41_platform_coder/env/itn-prod/terraform.tfvars
@@ -23,20 +23,27 @@ mcshared_dns_zone_prefix = "api-mcshared"
 
 ## Postgres
 keycloak_pgflex_params = {
-  sku_name   = "B_Standard_B2s"
+  enabled    = true
+  sku_name   = "GP_Standard_D4ds_v5"
   db_version = "16"
   # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
   # 2097152, 4194304, 8388608, 16777216, and 33554432.
   storage_mb                             = 32768
   zone                                   = 1
+  standby_zone                           = 2
   backup_retention_days                  = 30
-  geo_redundant_backup_enabled           = true
+  geo_redundant_backup_enabled           = false
   create_mode                            = "Default"
   pgres_flex_private_endpoint_enabled    = true
-  pgres_flex_ha_enabled                  = false
+  pgres_flex_ha_enabled                  = true
   pgres_flex_pgbouncer_enabled           = false
   pgres_flex_diagnostic_settings_enabled = false
   max_connections                        = 1700
   pgbouncer_min_pool_size                = 100
   pgbouncer_default_pool_size            = 100
+}
+
+keycloak_configuration = {
+  replica_count_min = 3
+  replica_count_max = 5
 }

--- a/src/41_platform_coder/env/itn-uat/terraform.tfvars
+++ b/src/41_platform_coder/env/itn-uat/terraform.tfvars
@@ -23,26 +23,14 @@ mcshared_dns_zone_prefix = "api-mcshared.uat"
 
 ## Postgres
 keycloak_pgflex_params = {
-  enabled    = true
-  sku_name   = "B_Standard_B2s"
-  db_version = "16"
-  # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
-  # 2097152, 4194304, 8388608, 16777216, and 33554432.
-  storage_mb                             = 32768
-  zone                                   = 1
-  backup_retention_days                  = 7
-  geo_redundant_backup_enabled           = false
-  create_mode                            = "Default"
-  pgres_flex_private_endpoint_enabled    = true
-  pgres_flex_ha_enabled                  = false
+  enabled                                = true
+  idh_resource_tier                      = "pgflex2"
+  geo_replication_enabled                = false
   pgres_flex_pgbouncer_enabled           = false
   pgres_flex_diagnostic_settings_enabled = false
-  max_connections                        = 1700
-  pgbouncer_min_pool_size                = 100
-  pgbouncer_default_pool_size            = 100
 }
 
 keycloak_configuration = {
-  replica_count_min = 1
-  replica_count_max = 2
+  replica_count_min = 2
+  replica_count_max = 3
 }

--- a/src/41_platform_coder/env/itn-uat/terraform.tfvars
+++ b/src/41_platform_coder/env/itn-uat/terraform.tfvars
@@ -26,6 +26,7 @@ keycloak_pgflex_params = {
   enabled                                = true
   idh_resource_tier                      = "pgflex2"
   geo_replication_enabled                = false
+  zone                                   = 1
   pgres_flex_pgbouncer_enabled           = false
   pgres_flex_diagnostic_settings_enabled = false
 }

--- a/src/tag_config/output.tf
+++ b/src/tag_config/output.tf
@@ -2,3 +2,8 @@ output "tags" {
   value       = local.tags
   description = "Tags to be applied to resources"
 }
+
+output "tags_grafana_yes" {
+  value       = merge(local.tags, { "grafana" = "yes" })
+  description = "Tags with 'grafana'='yes' to be applied to resources"
+}


### PR DESCRIPTION
### List of changes

- Introduced `zone` parameter to `keycloak_pgflex_params` for ITN environments.
- Refactored PostgreSQL configurations to streamline parameters across ITN environments.
- Updated module references to terraform-azurerm-v4 version 7.26.0.
- Aligned `idh_resource_tier` settings and disabled geo-replication by default.
- Added Grafana-specific tags with a new `tags_grafana_yes` output.
- Adjusted ITN-prod Postgres settings to enable HA, configure standby zone, and modify SKU and replication configurations.
- Updated `azurerm_resource_group` name to reference `platform_data_rg_name`.

### Motivation and context

These updates standardize infrastructure parameters across environments, improve compatibility with the Terraform module version 7.26.0, and enhance the ability to configure ITN-prod Postgres environments effectively. The changes also improve tagging for Grafana integration.

### Type of changes

- [X] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [X] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

Streamlining key parameters and updating module dependencies sets the groundwork for improved performance and maintainability across ITN environments.