### PR TITLE
feat: [IDP-2766] Add credentials to ITN and IDPay secrets files

### DIFF
--- a/src/20_security_kv/secrets/core/itn-prod/noedit_secret_enc.json
+++ b/src/20_security_kv/secrets/core/itn-prod/noedit_secret_enc.json
@@ -5,7 +5,7 @@
 	"cstar-itn-grafana-dashboard-bot-api-key": "ENC[AES256_GCM,data:qBPQfmEOotey2L/Nwd0U3O+fUMtqORu9slYqREoiVm06xw2sWo3xfF9x/b2LJA==,iv:Zy7CYNqrAMjS4vSxD1U+LTF1DdiQJh5iYhkKn+CfjOM=,tag:pE3IZWg3ZLGjamOmezjwSw==,type:str]",
 	"pagopa-subscription-id": "ENC[AES256_GCM,data:zVcy7G5FFC8jW0KT2mECRgH8sHAnWAHBeIonWAM2UIyIwiLZ,iv:sduNCUagnvYl6B6vnFbsUZnu94fKKIoHKxQRL0Qq8kM=,tag:lRR+iI6PVpXZeu1UDLdXpg==,type:str]",
 	"peered-rtp-eventhub-pip": "ENC[AES256_GCM,data:fNw++XHNUtA=,iv:WH0E2o6YvNvRlTDmwmicvAfIwOojKgYlkJKiDlAy+AA=,tag:nfMZtpNprNz7We3EqyJ18Q==,type:str]",
-	"terraform-client-secret-for-keycloak": "ENC[AES256_GCM,data:lzdVPmb8ikpOxxXPZyUy75jRpBg8nrw2KYQ/rrUZM+Y=,iv:SlNLnfHljc9KuKy3+StV0FAD90jkpMenQKgJZWgemBI=,tag:jObR6tS/UA8W+WUCWe6M8Q==,type:str]",
+	"terraform-client-secret-for-keycloak": "ENC[AES256_GCM,data:l3jzStrs5DH4Rj/OSproYQgb2bKlZFwJVnrT2KlLTbE=,iv:jlNbul9TFfFamCXJtJaRPRaj7NlOKWYlxWiSjDUP8DQ=,tag:FvOTN9rQS5QvydM5cbwGlA==,type:str]",
 	"sops": {
 		"azure_kv": [
 			{
@@ -16,8 +16,8 @@
 				"enc": "MD3N89QOztTaM-riA8J5bhxSznOxBqyigV_PFQ24Qc-EBXAW8hMWflq2ilE952V_gN1_jZisQAkSsL2XP2ydkNRtTkdoaBC6lVapDby6r2SrJ8DNAFa3NDGt0gZ1oLZRf7nXyX__vSnYS45Ar_DXk6h19iywB1DuFcYv7j_cYF6uZEua_ntSAjHZ3mWNz12ModFzIyYYzW47EQhEqbmdDQ1xGaFCNznyWyMuYbZa8c_9CLQZgbRSYSor7UgFH-cojdqiCOKN3quWax0CgjLpehFoP9RCwNzg1IORJcifUe_1oKsWcQfzBX02AO1M3nJElhIJV_sKv7-Kt3aEoFpoKg"
 			}
 		],
-		"lastmodified": "2025-07-22T14:37:53Z",
-		"mac": "ENC[AES256_GCM,data:JmoXGdJyIWUiUSyeXHrKzHw0ghapgiYZ7NbRWV84MdlEAwWheEw+evlKHWlK8h3AMUkYNeDnm+amYYkDAZ+dA6h19t2tUMZV0hVSaIQV2G79EK5f0SkJ9foNm4p0NwZk+GyJsFQ0qDFme/Bmg5VJdB9mw1b9EVCmQKDcrC54KGI=,iv:YGWbnM86uXiMI4RaG8dy/LE44XgEGDbB73I4RoJCgpc=,tag:i+mfKeDB2HP0CbMWkJHHSQ==,type:str]",
+		"lastmodified": "2025-07-23T07:23:43Z",
+		"mac": "ENC[AES256_GCM,data:QM1cUp4TLum9rlvuKdAVoKnjQ6GGluv3opspayY7ge6DKJ0liyWSQAUC4KuhWqAhMHxH5MPkfnyXUkH7iKjMBsMKjAMV6ZS5rSNqHCJk9bHutcyYfv2JtsrTpI5Rmu7OMthx0Ppxcv11PkZ+x610SA9OgMMnyo9SRSJULdtMCFc=,iv:Bay8a45Afzcfzw/lfzlqLOBEYNH8xoG6YafRoTJGKZE=,tag:YY4eV5/WR2S9cNBM2C8OVw==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.10.2"
 	}

--- a/src/20_security_kv/secrets/core/itn-prod/noedit_secret_enc.json
+++ b/src/20_security_kv/secrets/core/itn-prod/noedit_secret_enc.json
@@ -5,9 +5,8 @@
 	"cstar-itn-grafana-dashboard-bot-api-key": "ENC[AES256_GCM,data:qBPQfmEOotey2L/Nwd0U3O+fUMtqORu9slYqREoiVm06xw2sWo3xfF9x/b2LJA==,iv:Zy7CYNqrAMjS4vSxD1U+LTF1DdiQJh5iYhkKn+CfjOM=,tag:pE3IZWg3ZLGjamOmezjwSw==,type:str]",
 	"pagopa-subscription-id": "ENC[AES256_GCM,data:zVcy7G5FFC8jW0KT2mECRgH8sHAnWAHBeIonWAM2UIyIwiLZ,iv:sduNCUagnvYl6B6vnFbsUZnu94fKKIoHKxQRL0Qq8kM=,tag:lRR+iI6PVpXZeu1UDLdXpg==,type:str]",
 	"peered-rtp-eventhub-pip": "ENC[AES256_GCM,data:fNw++XHNUtA=,iv:WH0E2o6YvNvRlTDmwmicvAfIwOojKgYlkJKiDlAy+AA=,tag:nfMZtpNprNz7We3EqyJ18Q==,type:str]",
+	"terraform-client-secret-for-keycloak": "ENC[AES256_GCM,data:lzdVPmb8ikpOxxXPZyUy75jRpBg8nrw2KYQ/rrUZM+Y=,iv:SlNLnfHljc9KuKy3+StV0FAD90jkpMenQKgJZWgemBI=,tag:jObR6tS/UA8W+WUCWe6M8Q==,type:str]",
 	"sops": {
-		"kms": null,
-		"gcp_kms": null,
 		"azure_kv": [
 			{
 				"vault_url": "https://cstar-p-itn-core-kv.vault.azure.net",
@@ -17,11 +16,8 @@
 				"enc": "MD3N89QOztTaM-riA8J5bhxSznOxBqyigV_PFQ24Qc-EBXAW8hMWflq2ilE952V_gN1_jZisQAkSsL2XP2ydkNRtTkdoaBC6lVapDby6r2SrJ8DNAFa3NDGt0gZ1oLZRf7nXyX__vSnYS45Ar_DXk6h19iywB1DuFcYv7j_cYF6uZEua_ntSAjHZ3mWNz12ModFzIyYYzW47EQhEqbmdDQ1xGaFCNznyWyMuYbZa8c_9CLQZgbRSYSor7UgFH-cojdqiCOKN3quWax0CgjLpehFoP9RCwNzg1IORJcifUe_1oKsWcQfzBX02AO1M3nJElhIJV_sKv7-Kt3aEoFpoKg"
 			}
 		],
-		"hc_vault": null,
-		"age": null,
-		"lastmodified": "2025-06-17T08:53:36Z",
-		"mac": "ENC[AES256_GCM,data:OwirTSY+H/r3/tXixElF6xmViMXofyLdUYL9mZzqHhjONpX43wwoChJ4Q8qKc7VmQj60j0IeZk5pGej8Dq0VxKHdVP+Yt6bRtAIS5DF7OzeQLv1ukKigviJpozhjoMK4KJGCHUbFJTRdeINN84Hbi0KkdDodU990UYTBTObGFJA=,iv:kTZ9Pm42SnWbV+OniCwLBMkLt77kQlogBN9PEVJ0PLY=,tag:SyG8gQUOTbwKWhuT1K34pw==,type:str]",
-		"pgp": null,
+		"lastmodified": "2025-07-22T14:37:53Z",
+		"mac": "ENC[AES256_GCM,data:JmoXGdJyIWUiUSyeXHrKzHw0ghapgiYZ7NbRWV84MdlEAwWheEw+evlKHWlK8h3AMUkYNeDnm+amYYkDAZ+dA6h19t2tUMZV0hVSaIQV2G79EK5f0SkJ9foNm4p0NwZk+GyJsFQ0qDFme/Bmg5VJdB9mw1b9EVCmQKDcrC54KGI=,iv:YGWbnM86uXiMI4RaG8dy/LE44XgEGDbB73I4RoJCgpc=,tag:i+mfKeDB2HP0CbMWkJHHSQ==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.10.2"
 	}

--- a/src/20_security_kv/secrets/core/itn-uat/noedit_secret_enc.json
+++ b/src/20_security_kv/secrets/core/itn-uat/noedit_secret_enc.json
@@ -5,9 +5,8 @@
 	"grafana-itn-service-account-token-value": "ENC[AES256_GCM,data:02mqGj3zyPNJ6GFOf5W7Oyn63LhlU8T7PS5qngh9mwACM20TLZl9gbdKIoZQOw==,iv:JesJZtWw1kiXx7AAv48Kb5Wa4rY+shYbGc3LSTSmoxA=,tag:uL1k8y+XpyU/Re1z+t7uug==,type:str]",
 	"pagopa-subscription-id": "ENC[AES256_GCM,data:xnUV8oS8W3pfFm0eYgdmlq8yMA9av1lDk56vg4YIGoQ+tibt,iv:N2oqEyNg8XZfSFLpvtG5cUy6IH4lTCxoAZYZ7q5xOlY=,tag:W0MQI8jdqhyLH5azVUCLXQ==,type:str]",
 	"peered-rtp-eventhub-pip": "ENC[AES256_GCM,data:yTcPagHse+E=,iv:nax3l41YX+b4NQzB6JM/Ef5QBwWS7YKa+78ab9AAqMw=,tag:7/yiFMCg1XE6GD1WWBNTkw==,type:str]",
+	"terraform-client-secret-for-keycloak": "ENC[AES256_GCM,data:H5JczL6nd6xxSHSLMEUp7BI/1u0O6h3wEfCmLTVlGJ0=,iv:21XswYWJl5SneJ9Fg8/ipukkBblSe+qHSTLRIVrGZQQ=,tag:jizXaKs7oxKkv15CaxLn5g==,type:str]",
 	"sops": {
-		"kms": null,
-		"gcp_kms": null,
 		"azure_kv": [
 			{
 				"vault_url": "https://cstar-u-itn-core-kv.vault.azure.net",
@@ -17,11 +16,8 @@
 				"enc": "QyiYtExAhqgrICKzwxMbhdj4Nq9qXzxpGNw25o9yNFjfsTdBtNQv_ba_xKnkEhU2vJKH4TaDEhEp_4CMYaUpZnABSnb_xCTIoYBZYPkugLfINzYU59jWYJL6DoIqrGnX1zSxNP7l13SeddvEqBbaW7tnFM6C_k1vemL7safVeQj0Q6gLBFdSsmVrIqKTm_jYtGi2EwgnpQNytecBp4YDO6HYDRaWZgImpILSLEHNr_1PyC6I0qqAMsMbCVj5R2hGpWrKdtt_GQbs8EwaI9UBXXSDZIdhyc_GPy2XMt5akL5Zt5w11azepJHUP2Mn0rN9DcadVJa8zBedEivWjmmkbw"
 			}
 		],
-		"hc_vault": null,
-		"age": null,
-		"lastmodified": "2025-06-19T08:53:22Z",
-		"mac": "ENC[AES256_GCM,data:aNezaq62NVBLUWMTJbW2dC/CTjHP+reSoSDrD01W4f4GxvPF9tIdZgFQG2WtIiD5wxaSA5JqLbb2H3BCHgaA5CR1XQYhlSpZcuyzHkf+kj3OP3TD2pZVS2+U91hwYVfhfa10t7CXkDxGgkOAKYaJOepZxsI5dGpxlXilWVR7OzA=,iv:SpZQbTbUS99ToGv1+AyPbY0gS7oLM7YmjlTmF2rC/fk=,tag:Kupa3YVIzS/bHAFpUaRn2g==,type:str]",
-		"pgp": null,
+		"lastmodified": "2025-07-22T14:36:03Z",
+		"mac": "ENC[AES256_GCM,data:+mFoNV/02sjLDKuwI+90+ufI9W1VN96rElqw7qdg+GiiI3aRBF3hkmy1STGG51r3+FQ1LCl+Nz9MmdotKc1TgVnqH92pliwA500f8q6JTFUX1J+UeV9EgQhOxSBavVfTy3rael+gpdNy1abHzE43wTsaQ/Ojyn1YiSk6Wu46Us8=,iv:IP8LWfbLdzziAeTBKUV3el/hVr0sZg9orIA6UFS9oEA=,tag:pMvxUJedj9MqyuO/44/qoA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.10.2"
 	}

--- a/src/70_domains/idpay_security/secrets/idpay/itn-prod/noedit_secret_enc.json
+++ b/src/70_domains/idpay_security/secrets/idpay/itn-prod/noedit_secret_enc.json
@@ -29,6 +29,10 @@
 	"pagopa-pdnd-configuration-purpose-id-c001": "ENC[AES256_GCM,data:U3ZCIA==,iv:BD5fqvWtA5N1MN2mT2hBD0FeKS9I4PY6qLuTr0NigVc=,tag:o812QRNJ1l86jQdD3guLaA==,type:str]",
 	"pagopa-pdnd-configuration-purpose-id-c021": "ENC[AES256_GCM,data:b7R7+g==,iv:uVutgw3Exj0u+bDa8vRH43Q7n6NPGhizBfs8YWGYb0o=,tag:VFpVAWDjUTpwiyQKNjCQPQ==,type:str]",
 	"pdv-api-key": "ENC[AES256_GCM,data:QOC6pazfXNVTM5Gzp9nA9gLRcKtlQ7JeM2mVLXfajhn6CYzjh/F1rA==,iv:TAyTfFcFSB332jN45KiUee6qRpITuWRYkEl5OYAAu8E=,tag:dfxMHUvgWLfkw6rjLwUhzg==,type:str]",
+	"aws-ses-mail-smtp-username": "ENC[AES256_GCM,data:FtHLZfpDOWJWHYFhtFwfn4hN5OY=,iv:xJBF21hrYL2RSLeryln5JxwTyt2/GXoH0hQfTNcgxJQ=,tag:kQeBqbMG14v+njvVGiMvjA==,type:str]",
+	"aws-ses-mail-smtp-password": "ENC[AES256_GCM,data:me2H/8fFr+1igui1gASaoe2KAeb9ICDQ0Pwbt1bxOsQJg+8rE5ANZ3aziSE=,iv:AwJjWOhcxoV1Sf3Q/At7ljeJnkPWWukxwyEWNY8JQ2s=,tag:9Qo+WoHKrPhmkr37Iqe4Ew==,type:str]",
+	"aws-ses-mail-host": "ENC[AES256_GCM,data:7q9sU5lawM/rfZFLdAG0pZ3sN9nKBSn8X8aAHyqm47OGX0qYEA==,iv:KWtQojgtD7Rwm5+nd+/aQWEoKmlRAQXaVNFFyzubThA=,tag:ocjhQG5MWc+0OMZDDvacRg==,type:str]",
+	"aws-ses-mail-from": "ENC[AES256_GCM,data:N2ARAUWcljaAd0L4vtQih6bZ4ShlfbY=,iv:7E3w2ZUT3t37H2TRPFdIhml66bAwJgtjR01WPuf/Gko=,tag:ds+3LAWWlhPnPF8BuTDJug==,type:str]",
 	"sops": {
 		"azure_kv": [
 			{
@@ -39,8 +43,8 @@
 				"enc": "QjF_0Tcvq0KlvV9xVAv5vruWopmZlvJYWOqacjoxP5fE3WTjPKYcgSi0ClWmIaKGpHKaR9keX-2dURdSMry1huTspeZ9CnDOXkNj0R7A3oH-WPtttyp121YadzsB0x8B7R55Sezd5TxcCQRa_4yx9sODhonZp1ehc7Qx8cmCUUQoYtWVDnVWhbDrvUX0mPRx2h5WvlYRBEhAm41i65dNIjZrNQab0ugStjQF6Z6mfdHij6XoxHQEE5PlnJJFtfx8SPY7AhIlV2zq2yACHFNcaVVRc_uxjJ9iNYpvlen1mgEicUworRskKfaqB_f736MiWDVHIZ3TtqpnOYY6L2-vbA"
 			}
 		],
-		"lastmodified": "2025-07-21T08:20:03Z",
-		"mac": "ENC[AES256_GCM,data:bGo2jJgMJjO9QDSPNRjvUTbfMK0iZhYu0LTFhDPVPOTGI5y7xf9y4xvZcAMpIxGwWRJcGYJSCBvURXLBzYfuidGJwzwN9MVBaTACbyHETlTFCwHoMVzY20w3bzU1n9pLvLhXmQeclzUO85TbHUwoR6z1IDHaQ7ZmdEa8f0OssCM=,iv:FEkU92+vjT5riC/r88HGSD2novD4vGTTwW84vPVqHwE=,tag:GfQmqBQCCPt5UNrddCJGwg==,type:str]",
+		"lastmodified": "2025-07-22T14:57:24Z",
+		"mac": "ENC[AES256_GCM,data:b1lfMXq1yaisNZx+eF8Iyk7P5gmHWnC9V9sb3fpHyx+d/MkhkMyfgFrfHT2FRKuCUau5E6ztwyWEhB/qgztm0oq2sgcm6m6O7QFo8ojijluniTFGPH2GDvD63OqeTT3cBSoTgRYvR5JYDQyz50Sb675qMPZR+Nnv7tbnTWZDky0=,iv:ii6FoGAdAVP/pZzxWkC4Quc6pqDxzZ+Aw5SfaCypdZ4=,tag:IILC/pkbjgnGmNL9vNnJwQ==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.10.2"
 	}

--- a/src/70_domains/idpay_security/secrets/idpay/itn-prod/noedit_secret_enc.json
+++ b/src/70_domains/idpay_security/secrets/idpay/itn-prod/noedit_secret_enc.json
@@ -1,4 +1,6 @@
 {
+	"argocd-admin-username": "ENC[AES256_GCM,data:KjJKjjs=,iv:YJiO1D9CP6bVXYi5Fmy1plCYfTM59rlqUe8Tmdql6VU=,tag:hzCvRzysbxVpNxiKrBNEHw==,type:str]",
+	"argocd-admin-password": "ENC[AES256_GCM,data:+tVg4H5vTtRanYGfaa0MPcxgXfgFW62dtwCZLw==,iv:oyoBZs2QlK4XOqJhztMDmCZTqHNHiOs3ckiLgcOqsb4=,tag:rF0kofDi3OsYmry6eLNX+Q==,type:str]",
 	"idpay-bot-github-pr-TOKEN": "ENC[AES256_GCM,data:H6xTqyI2eX2JYMUi01krYYt2sNO+q50Xzeph0VgvL4F+H9/bSZcAqw==,iv:4iZc7Esz6YFM8uuKtoNux6AOBA6MDtW+HjQZhxuhSYQ=,tag:pXtpFzf1l59OzoY8rqwG0w==,type:str]",
 	"idpay-bot-github-ro-TOKEN": "ENC[AES256_GCM,data:04IX7VFSly16+LmRYIf3oruXq4oVx6+X6F3s+ZE/X2evGkrubwc5rg==,iv:U1/7V/5vCoWDV4I+q5W4IXDgKWLWkWu2VGVXST7ns0o=,tag:XfYgi2QN2N+hR5bDMPRCdQ==,type:str]",
 	"idpay-bot-github-rw-TOKEN": "ENC[AES256_GCM,data:OgRGQJGNGr2ERZfd53AHx1dRUXfNkUvIqSc/WBRUos+iffKajpN60w==,iv:VdcpfyI8BIvkItYoz8b8SFt+EiTGTF+AghOmQzHi2YU=,tag:B4igfZ5cRjvEhxMUFm6h4w==,type:str]",
@@ -37,8 +39,8 @@
 				"enc": "QjF_0Tcvq0KlvV9xVAv5vruWopmZlvJYWOqacjoxP5fE3WTjPKYcgSi0ClWmIaKGpHKaR9keX-2dURdSMry1huTspeZ9CnDOXkNj0R7A3oH-WPtttyp121YadzsB0x8B7R55Sezd5TxcCQRa_4yx9sODhonZp1ehc7Qx8cmCUUQoYtWVDnVWhbDrvUX0mPRx2h5WvlYRBEhAm41i65dNIjZrNQab0ugStjQF6Z6mfdHij6XoxHQEE5PlnJJFtfx8SPY7AhIlV2zq2yACHFNcaVVRc_uxjJ9iNYpvlen1mgEicUworRskKfaqB_f736MiWDVHIZ3TtqpnOYY6L2-vbA"
 			}
 		],
-		"lastmodified": "2025-05-14T09:14:50Z",
-		"mac": "ENC[AES256_GCM,data:+zTG/kGJrDA9HK8T/dHgK9wyAp7Acab6HUR1skQr5y1wuMtoYKaedd+kIX4mlo86s9JVteYu00KSea6TWOBceDBn+4Ueg7r5Cjr47NYZM95D9UxEwjwVmGP7TS8GnLGohJ2xCigK0jtlQImiSeGyI8aaqcYW9Ows3QTUoeUBBk0=,iv:NWbEVmXLPNLHkyGFtmpUAii1VSAuNViRQOmp1Wr7A1M=,tag:3BKqXZFojBbhpRuMsLzxtA==,type:str]",
+		"lastmodified": "2025-07-21T08:20:03Z",
+		"mac": "ENC[AES256_GCM,data:bGo2jJgMJjO9QDSPNRjvUTbfMK0iZhYu0LTFhDPVPOTGI5y7xf9y4xvZcAMpIxGwWRJcGYJSCBvURXLBzYfuidGJwzwN9MVBaTACbyHETlTFCwHoMVzY20w3bzU1n9pLvLhXmQeclzUO85TbHUwoR6z1IDHaQ7ZmdEa8f0OssCM=,iv:FEkU92+vjT5riC/r88HGSD2novD4vGTTwW84vPVqHwE=,tag:GfQmqBQCCPt5UNrddCJGwg==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.10.2"
 	}

--- a/src/70_domains/idpay_security/secrets/idpay/itn-prod/noedit_secret_enc.json
+++ b/src/70_domains/idpay_security/secrets/idpay/itn-prod/noedit_secret_enc.json
@@ -29,10 +29,6 @@
 	"pagopa-pdnd-configuration-purpose-id-c001": "ENC[AES256_GCM,data:U3ZCIA==,iv:BD5fqvWtA5N1MN2mT2hBD0FeKS9I4PY6qLuTr0NigVc=,tag:o812QRNJ1l86jQdD3guLaA==,type:str]",
 	"pagopa-pdnd-configuration-purpose-id-c021": "ENC[AES256_GCM,data:b7R7+g==,iv:uVutgw3Exj0u+bDa8vRH43Q7n6NPGhizBfs8YWGYb0o=,tag:VFpVAWDjUTpwiyQKNjCQPQ==,type:str]",
 	"pdv-api-key": "ENC[AES256_GCM,data:QOC6pazfXNVTM5Gzp9nA9gLRcKtlQ7JeM2mVLXfajhn6CYzjh/F1rA==,iv:TAyTfFcFSB332jN45KiUee6qRpITuWRYkEl5OYAAu8E=,tag:dfxMHUvgWLfkw6rjLwUhzg==,type:str]",
-	"aws-ses-mail-smtp-username": "ENC[AES256_GCM,data:FtHLZfpDOWJWHYFhtFwfn4hN5OY=,iv:xJBF21hrYL2RSLeryln5JxwTyt2/GXoH0hQfTNcgxJQ=,tag:kQeBqbMG14v+njvVGiMvjA==,type:str]",
-	"aws-ses-mail-smtp-password": "ENC[AES256_GCM,data:me2H/8fFr+1igui1gASaoe2KAeb9ICDQ0Pwbt1bxOsQJg+8rE5ANZ3aziSE=,iv:AwJjWOhcxoV1Sf3Q/At7ljeJnkPWWukxwyEWNY8JQ2s=,tag:9Qo+WoHKrPhmkr37Iqe4Ew==,type:str]",
-	"aws-ses-mail-host": "ENC[AES256_GCM,data:7q9sU5lawM/rfZFLdAG0pZ3sN9nKBSn8X8aAHyqm47OGX0qYEA==,iv:KWtQojgtD7Rwm5+nd+/aQWEoKmlRAQXaVNFFyzubThA=,tag:ocjhQG5MWc+0OMZDDvacRg==,type:str]",
-	"aws-ses-mail-from": "ENC[AES256_GCM,data:N2ARAUWcljaAd0L4vtQih6bZ4ShlfbY=,iv:7E3w2ZUT3t37H2TRPFdIhml66bAwJgtjR01WPuf/Gko=,tag:ds+3LAWWlhPnPF8BuTDJug==,type:str]",
 	"sops": {
 		"azure_kv": [
 			{
@@ -43,8 +39,8 @@
 				"enc": "QjF_0Tcvq0KlvV9xVAv5vruWopmZlvJYWOqacjoxP5fE3WTjPKYcgSi0ClWmIaKGpHKaR9keX-2dURdSMry1huTspeZ9CnDOXkNj0R7A3oH-WPtttyp121YadzsB0x8B7R55Sezd5TxcCQRa_4yx9sODhonZp1ehc7Qx8cmCUUQoYtWVDnVWhbDrvUX0mPRx2h5WvlYRBEhAm41i65dNIjZrNQab0ugStjQF6Z6mfdHij6XoxHQEE5PlnJJFtfx8SPY7AhIlV2zq2yACHFNcaVVRc_uxjJ9iNYpvlen1mgEicUworRskKfaqB_f736MiWDVHIZ3TtqpnOYY6L2-vbA"
 			}
 		],
-		"lastmodified": "2025-07-22T14:57:24Z",
-		"mac": "ENC[AES256_GCM,data:b1lfMXq1yaisNZx+eF8Iyk7P5gmHWnC9V9sb3fpHyx+d/MkhkMyfgFrfHT2FRKuCUau5E6ztwyWEhB/qgztm0oq2sgcm6m6O7QFo8ojijluniTFGPH2GDvD63OqeTT3cBSoTgRYvR5JYDQyz50Sb675qMPZR+Nnv7tbnTWZDky0=,iv:ii6FoGAdAVP/pZzxWkC4Quc6pqDxzZ+Aw5SfaCypdZ4=,tag:IILC/pkbjgnGmNL9vNnJwQ==,type:str]",
+		"lastmodified": "2025-07-23T08:28:11Z",
+		"mac": "ENC[AES256_GCM,data:Jd0xbA29xTj6HE+Wxsxop8ZGuoYLAh1dT1ndZzZXWsHR0YrFGiKtTmgSbDopvqULIPlHFmQsdTCbAmYiUtnLhrUnNyUtVJqTFUxUmhHGgRRuN6w3c+B71INtEP4Gl1G6sS7S4pCsMv2BzTwT1xi6cSqSCyAfKZ4nZqNf4wgPcp4=,iv:PHX/ZXgvfLIjRuDXWyiTwVwfXoouQfyo79WI/hmkbgg=,tag:c7GdffP+VqcBO6O6sY0yMA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.10.2"
 	}


### PR DESCRIPTION
### List of changes

- Added Keycloak and AWS SES credentials to the ITN and IDPay secrets files.
- Added ArgoCD admin credentials to the ITN production secrets file.

### Motivation and context

This change ensures that the necessary credentials for Keycloak, AWS SES, and ArgoCD are available in the ITN and IDPay environments, enabling secure and seamless operation of the respective services.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

None. 

--- 

### If PR is partially applied, why? (reserved to mantainers)

None.