### PR TITLE
fix: change number of approval required in PRs

### DIFF
--- a/src/91_github/idpay/02_branch_protection.tf
+++ b/src/91_github/idpay/02_branch_protection.tf
@@ -31,7 +31,7 @@ resource "github_repository_ruleset" "dev" {
 
     pull_request {
       require_code_owner_review         = true
-      required_approving_review_count   = 1
+      required_approving_review_count   = 2
       dismiss_stale_reviews_on_push     = true
       required_review_thread_resolution = true
     }
@@ -63,7 +63,7 @@ resource "github_repository_ruleset" "uat_prod" {
 
     pull_request {
       require_code_owner_review         = true
-      required_approving_review_count   = 1
+      required_approving_review_count   = 2
       dismiss_stale_reviews_on_push     = true
       required_review_thread_resolution = true
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to change the number of approvals from 1 to 2 to make a PR mergeable
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
