### PR TITLE
feat: [IDP-2786] Update DNS and SES configurations for non-production environments

### DIFF
--- a/src/90_aws/02_core/99_locals.tf
+++ b/src/90_aws/02_core/99_locals.tf
@@ -1,13 +1,13 @@
 locals {
   product = "${var.prefix}-${var.env_short}"
 
-  public_dns_zone_name = var.env != "prod" ? "${var.env}.${var.prefix}.pagopa.it" : "${var.prefix}.pagopa.it"
+  public_dns_zone_name = var.env != "prod" ? "${var.env}.bonuselettrodomestici.pagopa.it" : "bonuselettrodomestici.pagopa.it"
 
-  vnet_legacy_rg = "${local.product}-vnet-rg"
+  vnet_legacy_rg = "${local.product}-${var.location_short}-core-network-rg"
 
   ## SMTP settings for Amazon SES
   iam_ses_user      = "${var.prefix}-${var.env}-ses-user"
-  ses_domain        = var.env != "prod" ? "${var.env}.${var.prefix}.pagopa.it" : "${var.prefix}.pagopa.it"
+  ses_domain        = var.env != "prod" ? "${var.env}.bonuselettrodomestici.pagopa.it" : "bonuselettrodomestici.pagopa.it"
   ses_username      = "noreply"
   ses_smtp_host     = "email-smtp.${var.aws_region}.amazonaws.com"
   ses_smtp_port     = 465

--- a/src/90_aws/02_core/99_locals.tf
+++ b/src/90_aws/02_core/99_locals.tf
@@ -1,7 +1,7 @@
 locals {
   product = "${var.prefix}-${var.env_short}"
 
-  public_dns_zone_name = var.env != "prod" ? "${var.env}.bonuselettrodomestici.pagopa.it" : "bonuselettrodomestici.pagopa.it"
+  public_dns_zone_name = var.env != "prod" ? "${var.env}.${var.prefix}.pagopa.it" : "${var.prefix}.pagopa.it"
 
   vnet_legacy_rg = "${local.product}-vnet-rg"
 

--- a/src/90_aws/02_core/99_locals.tf
+++ b/src/90_aws/02_core/99_locals.tf
@@ -7,7 +7,7 @@ locals {
 
   ## SMTP settings for Amazon SES
   iam_ses_user      = "${var.prefix}-${var.env}-ses-user"
-  ses_domain        = var.env != "prod" ? "${var.env}.bonuselettrodomestici.pagopa.it" : "bonuselettrodomestici.pagopa.it"
+  ses_domain        = var.env != "prod" ? "${var.env}.${var.prefix}.pagopa.it" : "${var.prefix}.pagopa.it"
   ses_username      = "noreply"
   ses_smtp_host     = "email-smtp.${var.aws_region}.amazonaws.com"
   ses_smtp_port     = 465

--- a/src/90_aws/02_core/99_locals.tf
+++ b/src/90_aws/02_core/99_locals.tf
@@ -1,13 +1,13 @@
 locals {
   product = "${var.prefix}-${var.env_short}"
 
-  public_dns_zone_name = var.env != "prod" ? "${var.env}.${var.prefix}.pagopa.it" : "${var.prefix}.pagopa.it"
+  public_dns_zone_name = var.env != "prod" ? "${var.env}.bonuselettrodomestici.pagopa.it" : "bonuselettrodomestici.pagopa.it"
 
   vnet_legacy_rg = "${local.product}-vnet-rg"
 
   ## SMTP settings for Amazon SES
   iam_ses_user      = "${var.prefix}-${var.env}-ses-user"
-  ses_domain        = var.env != "prod" ? "${var.env}.${var.prefix}.pagopa.it" : "${var.prefix}.pagopa.it"
+  ses_domain        = var.env != "prod" ? "${var.env}.bonuselettrodomestici.pagopa.it" : "bonuselettrodomestici.pagopa.it"
   ses_username      = "noreply"
   ses_smtp_host     = "email-smtp.${var.aws_region}.amazonaws.com"
   ses_smtp_port     = 465


### PR DESCRIPTION
### List of changes

- Updated DNS configurations for the "bonuselettrodomestici" environment.
- Modified SES domain to include `prefix` in non-production environments.
- Adjusted DNS structure to accommodate `prefix` in non-production setups.
- Refreshed references to DNS and SES domains for "bonuselettrodomestici" configuration.

### Motivation and context

These changes are required to ensure proper DNS and SES setup in non-production environments. Including `prefix` in the configurations aids in better environment segregation and avoids conflicts.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

No additional information is necessary for the current scope of this PR.

---

### If PR is partially applied, why? (reserved to mantainers)

N/A