### PR TITLE
fix: [IDP-2766] Add encrypted secrets and update metadata for ITN production

### DIFF
--- a/src/70_domains/idpay_security/secrets/idpay/itn-prod/noedit_secret_enc.json
+++ b/src/70_domains/idpay_security/secrets/idpay/itn-prod/noedit_secret_enc.json
@@ -32,6 +32,7 @@
 	"mil-auth-webview-client-id": "ENC[AES256_GCM,data:wl6toiYooV8K9tUjddzeDHZNajH9Uz58c4GOJEjpTKjN0nUV,iv:PvSUZRrH/BFmDsfv5hDY5HnWG0aThLkWF3U/Exss2TY=,tag:jHEnRT4i/WXm8vyt4n+k7A==,type:str]",
 	"pm-api-key": "ENC[AES256_GCM,data:3SDKOClyVkDwP/qGb+SfITz8nBlxrCS61dZrAas27Q4=,iv:mPtttNXMczAimQf+WCsOBxO3UiHv8CKdvvBAkF41wPI=,tag:i6gySMhTuo9VLfAm7Ji01w==,type:str]",
 	"web-storage-connection-string": "ENC[AES256_GCM,data:hgxHEXxDGDP/PwDRaTQ2uxB7JXusKdIQKChYpjOEJ72Jucn9Sqmul/tidoV5c3I0StZBXCCrx4tpdSE59wNNJW/+m8LzskEIjgJe6vGx6KHeOx8JAD7kwdzy7XXMCkt4SZ7385YTGf8IgaOQEB4lrD/jmafn1/E0pIaQGNyWxtV8tCvpwdfNk2dsguoWUb7PJ0/QaB8k2+Lw889ParJhkpvG2feZQtVrlxnozIkxYZSfKZbqKfweLYikcfZmaLQqUKn7/rROaA==,iv:SwBoOi95+Uls/RgcFLBcYwO1UdXnhMHGxViCoypGVUg=,tag:+SDXxvpvN70ZwUcWIfHwTg==,type:str]",
+	"mil-auth-webview-client-secret": "ENC[AES256_GCM,data:PkKZLV0snnOnSf3YVR9wqQ4MJ4IryHzkj//mIlXFGFmo74+q,iv:SHa8aaqPThYQaptJOghjP1PK2uiMobwH/EGRkW/f5bM=,tag:VPgftbbEQWXJN/yLkroEQw==,type:str]",
 	"sops": {
 		"azure_kv": [
 			{
@@ -42,8 +43,8 @@
 				"enc": "QjF_0Tcvq0KlvV9xVAv5vruWopmZlvJYWOqacjoxP5fE3WTjPKYcgSi0ClWmIaKGpHKaR9keX-2dURdSMry1huTspeZ9CnDOXkNj0R7A3oH-WPtttyp121YadzsB0x8B7R55Sezd5TxcCQRa_4yx9sODhonZp1ehc7Qx8cmCUUQoYtWVDnVWhbDrvUX0mPRx2h5WvlYRBEhAm41i65dNIjZrNQab0ugStjQF6Z6mfdHij6XoxHQEE5PlnJJFtfx8SPY7AhIlV2zq2yACHFNcaVVRc_uxjJ9iNYpvlen1mgEicUworRskKfaqB_f736MiWDVHIZ3TtqpnOYY6L2-vbA"
 			}
 		],
-		"lastmodified": "2025-07-24T14:57:03Z",
-		"mac": "ENC[AES256_GCM,data:GeXk/KpWXruvAnwItV4UTlpMPV2+HxzLwkfCeDyb7p/yReGdbZli65Kd3H00g0ELma8kRr7LVaQa15kvupc66dKsag+VtsV2Cf1NfN1sfqdDmlww8S7+95qEXvCcRpSFt0tV+rdh/Q0zU/V76OXWwO5UQPc9Xiyll4JQqupEbC4=,iv:4ry8r7FDWSsxWXfrJnop1oijCDXPKH6i5TJ8lfcFiXw=,tag:qDurJuT0KfGjXrlk5E5VDw==,type:str]",
+		"lastmodified": "2025-07-24T15:00:52Z",
+		"mac": "ENC[AES256_GCM,data:cuSh1X6iyNpnqLTDyHSNdS6IoaaIJ4kRqdnTwvm6u3XFhEuSTknz/ba1VZM7G6etXAOfpnIlx+A9T/yPFJIuIJMG5vZMuuHXleOxl0tOCN51F/oFpTqoNyLAwRcGz6I3LL/U8wqxlUdP01Xa6m9qqyqSJ0tIKB3x6iGxjhHrvxk=,iv:Pc76TQll7tvNbffSiPLRTC+FCgKuwYdnjnFlbeJn3Ek=,tag:06GI2qCxgdWrNPHq8t339A==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.10.2"
 	}


### PR DESCRIPTION
### List of changes

- Added new encrypted secrets required for ITN production environment.
- Updated metadata configuration for ITN production resources.

### Motivation and context

This change is necessary to ensure secure handling of secrets and to update metadata to align with ITN production environment requirements.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

N/A

---

### If PR is partially applied, why? (reserved to mantainers)

N/A