### PR TITLE
feat: [IDP-2766] Add `selfcare-api-key` to ITN production configuration

### DIFF
--- a/src/70_domains/idpay_security/secrets/idpay/itn-prod/noedit_secret_enc.json
+++ b/src/70_domains/idpay_security/secrets/idpay/itn-prod/noedit_secret_enc.json
@@ -33,6 +33,7 @@
 	"pm-api-key": "ENC[AES256_GCM,data:3SDKOClyVkDwP/qGb+SfITz8nBlxrCS61dZrAas27Q4=,iv:mPtttNXMczAimQf+WCsOBxO3UiHv8CKdvvBAkF41wPI=,tag:i6gySMhTuo9VLfAm7Ji01w==,type:str]",
 	"web-storage-connection-string": "ENC[AES256_GCM,data:hgxHEXxDGDP/PwDRaTQ2uxB7JXusKdIQKChYpjOEJ72Jucn9Sqmul/tidoV5c3I0StZBXCCrx4tpdSE59wNNJW/+m8LzskEIjgJe6vGx6KHeOx8JAD7kwdzy7XXMCkt4SZ7385YTGf8IgaOQEB4lrD/jmafn1/E0pIaQGNyWxtV8tCvpwdfNk2dsguoWUb7PJ0/QaB8k2+Lw889ParJhkpvG2feZQtVrlxnozIkxYZSfKZbqKfweLYikcfZmaLQqUKn7/rROaA==,iv:SwBoOi95+Uls/RgcFLBcYwO1UdXnhMHGxViCoypGVUg=,tag:+SDXxvpvN70ZwUcWIfHwTg==,type:str]",
 	"mil-auth-webview-client-secret": "ENC[AES256_GCM,data:PkKZLV0snnOnSf3YVR9wqQ4MJ4IryHzkj//mIlXFGFmo74+q,iv:SHa8aaqPThYQaptJOghjP1PK2uiMobwH/EGRkW/f5bM=,tag:VPgftbbEQWXJN/yLkroEQw==,type:str]",
+	"selfcare-api-key": "ENC[AES256_GCM,data:jS1PVN/4hPpdm2NrILCTEAcM4GDAEUuJd/+un+Jb9Ng=,iv:3JX+3AHpvAqyypuGlM4dGbLH0CEMLc1h5qFu6NI98q8=,tag:Qlj2T6owkdFg3mwCGmwRWw==,type:str]",
 	"sops": {
 		"azure_kv": [
 			{
@@ -43,8 +44,8 @@
 				"enc": "QjF_0Tcvq0KlvV9xVAv5vruWopmZlvJYWOqacjoxP5fE3WTjPKYcgSi0ClWmIaKGpHKaR9keX-2dURdSMry1huTspeZ9CnDOXkNj0R7A3oH-WPtttyp121YadzsB0x8B7R55Sezd5TxcCQRa_4yx9sODhonZp1ehc7Qx8cmCUUQoYtWVDnVWhbDrvUX0mPRx2h5WvlYRBEhAm41i65dNIjZrNQab0ugStjQF6Z6mfdHij6XoxHQEE5PlnJJFtfx8SPY7AhIlV2zq2yACHFNcaVVRc_uxjJ9iNYpvlen1mgEicUworRskKfaqB_f736MiWDVHIZ3TtqpnOYY6L2-vbA"
 			}
 		],
-		"lastmodified": "2025-07-24T15:00:52Z",
-		"mac": "ENC[AES256_GCM,data:cuSh1X6iyNpnqLTDyHSNdS6IoaaIJ4kRqdnTwvm6u3XFhEuSTknz/ba1VZM7G6etXAOfpnIlx+A9T/yPFJIuIJMG5vZMuuHXleOxl0tOCN51F/oFpTqoNyLAwRcGz6I3LL/U8wqxlUdP01Xa6m9qqyqSJ0tIKB3x6iGxjhHrvxk=,iv:Pc76TQll7tvNbffSiPLRTC+FCgKuwYdnjnFlbeJn3Ek=,tag:06GI2qCxgdWrNPHq8t339A==,type:str]",
+		"lastmodified": "2025-07-25T08:51:21Z",
+		"mac": "ENC[AES256_GCM,data:BxSsPdOk9lSSOwBxIurRKsWFJXd7nwm3qxPH37kDuhWl2TTt6UbZbCmMvLkgqPQjoHpwa7sn6cilacsLfT/BqtHUIXWnP6A4nLCtR73x/H2o7wwuvufx7wg3WYUJ4gEO8YjKsYTtl+xSRJS1K45f9N/IvF970RtPNh+ezdYsBfw=,iv:o14j6kuCrcrDaIVjFTpctKW2Q9KV7MMVATBx/JCqy6k=,tag:bBhWfm7Yj/d5+c1gOElXCA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.10.2"
 	}


### PR DESCRIPTION
### List of changes

- Added `selfcare-api-key` to the encrypted secrets configuration for ITN production.
- Updated `lastmodified` and `mac` fields in the configuration.

### Motivation and context

This change is required to include the new API key (`selfcare-api-key`) in the ITN production configuration, ensuring proper authentication and functionality.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

N/A

---

### If PR is partially applied, why? (reserved to mantainers)

N/A