### PR TITLE
feat: [IDP-2788] Reduce Event Hub namespace capacity in ITN production.

### DIFF
--- a/src/70_domains/idpay_common/env/itn-prod/terraform.tfvars
+++ b/src/70_domains/idpay_common/env/itn-prod/terraform.tfvars
@@ -36,7 +36,7 @@ service_bus_namespace = {
 
 ##Eventhub
 ehns_sku_name                 = "Standard"
-ehns_capacity                 = 5
+ehns_capacity                 = 1
 ehns_maximum_throughput_units = 5
 ehns_auto_inflate_enabled     = true
 ehns_alerts_enabled           = true


### PR DESCRIPTION
### List of changes

- Reduced Event Hub namespace capacity to 1 unit in the ITN production environment.

### Motivation and context

- This change optimizes resource allocation to better align with the current usage requirements in the ITN production environment.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

N/A

---

### If PR is partially applied, why? (reserved to mantainers)

N/A