### PR TITLE
fix: Update redis module uat with private endpoint

### DIFF
--- a/src/70_domains/idpay_common/99_main.tf
+++ b/src/70_domains/idpay_common/99_main.tf
@@ -48,8 +48,8 @@ provider "azurerm" {
 }
 
 module "__v4__" {
-  # https://github.com/pagopa/terraform-azurerm-v4/releases/tag/v7.26.2
-  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git?ref=185b6e434c85494d33a164aac0d004fd5012e126"
+  # https://github.com/pagopa/terraform-azurerm-v4/releases/tag/v7.26.5
+  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git?ref=34656073b57f687059ebeeaee7ae9a9616071ae4"
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
### List of changes

- Updated the `terraform-azurerm-v4` module to version `7.26.5`.

### Motivation and context

- This update ensures we are using a more up-to-date version of the module, which may include bug fixes, performance improvements, or new functionality.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources
- [x] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

- No further information to provide at this moment.

--- 

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->