### PR TITLE
fix: removed special chars from keycloak client secret

### DIFF
--- a/src/70_domains/idpay_common/10_keycloak.tf
+++ b/src/70_domains/idpay_common/10_keycloak.tf
@@ -56,8 +56,8 @@ resource "keycloak_openid_client" "merchant_operator_frontend" {
 }
 
 resource "random_password" "keycloak_merchant_operator_app_client" {
-  length           = 30
-  special          = false
+  length  = 30
+  special = false
 }
 
 resource "azurerm_key_vault_secret" "keycloak_merchant_operator_app_client_secret" {

--- a/src/70_domains/idpay_common/10_keycloak.tf
+++ b/src/70_domains/idpay_common/10_keycloak.tf
@@ -56,9 +56,8 @@ resource "keycloak_openid_client" "merchant_operator_frontend" {
 }
 
 resource "random_password" "keycloak_merchant_operator_app_client" {
-  length           = 24
-  special          = true
-  override_special = "*()-+[]{}<>:?"
+  length           = 30
+  special          = false
 }
 
 resource "azurerm_key_vault_secret" "keycloak_merchant_operator_app_client_secret" {
@@ -77,7 +76,7 @@ resource "keycloak_openid_client" "merchant_operator_app_client" {
 
   client_id                = "merchant-operator-app-client"
   client_secret_wo         = random_password.keycloak_merchant_operator_app_client.result
-  client_secret_wo_version = 2
+  client_secret_wo_version = 3
 
   access_type              = "CONFIDENTIAL"
   service_accounts_enabled = true


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to remove the special chars from the client secret (the one used by pods to access merchant-operator realm in keycloak) and to increase the length to 30 chars.
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
