### PR TITLE
fix: Update dashboard title in Azure Cost Analysis configuration

### DIFF
--- a/src/49_grafanaconf/custom_dashboard/azurecostanalysisinfinity.json
+++ b/src/49_grafanaconf/custom_dashboard/azurecostanalysisinfinity.json
@@ -2483,7 +2483,7 @@
     "refresh_intervals": []
   },
   "timezone": "",
-  "title": "PAGOPA Domain costs",
+  "title": "CSTAR Domain costs",
   "uid": "cexqngywsa48wd",
   "version": 9
 }


### PR DESCRIPTION
### List of changes

- Updated the dashboard title in Azure Cost Analysis configuration to 'CSTAR Domain costs'.

### Motivation and context

- The update ensures the dashboard title aligns with the current naming conventions, improving clarity and consistency.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

---

### If PR is partially applied, why? (reserved to mantainers)