### PR TITLE
fix: update index key for pendingTrx in MongoDB configuration

### DIFF
--- a/src/70_domains/idpay_common/03_cosmos_mongodb_idpays_shared.tf
+++ b/src/70_domains/idpay_common/03_cosmos_mongodb_idpays_shared.tf
@@ -413,7 +413,7 @@ locals {
         { keys = ["_id"], unique = true },
         { keys = ["entityId"], unique = false },
         { keys = ["initiativeId"], unique = false },
-        { keys = ["pendingTrx.id"], unique = false }
+        { keys = ["pendingTrx._id"], unique = false }
       ]
     },
     {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Updates the MongoDB (Cosmos DB) collection index definition for user_initiative_counters to reflect a different field path for pendingTrx.

### List of changes
Changed the indexed field from pendingTrx.id to pendingTrx._id in the user_initiative_counters collection indexes list.
<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
