### PR TITLE
fix: [SRTP-1703] correct workload identity and ADX principal assignment for rtp-sender

### DIFF
--- a/src/70_domains/srtp_common/00_data.tf
+++ b/src/70_domains/srtp_common/00_data.tf
@@ -168,5 +168,5 @@ data "azurerm_kusto_cluster" "kusto_cluster" {
 #
 data "azurerm_user_assigned_identity" "rtp_sender_workload_identity" {
   name                = local.rtp_sender_workload_identity_name
-  resource_group_name = local.identity_rg_name
+  resource_group_name = local.rtp_sender_workload_identity_rg_name
 }

--- a/src/70_domains/srtp_common/62_dataexplorer.tf
+++ b/src/70_domains/srtp_common/62_dataexplorer.tf
@@ -50,7 +50,7 @@ resource "azurerm_data_factory_linked_service_kusto" "kusto" {
 }
 
 resource "azurerm_kusto_database_principal_assignment" "rtp_sender_adx_viewer" {
-  name                = "rtp-sender-viewer"
+  name                = "rtp-role-viewer"
   resource_group_name = data.azurerm_kusto_cluster.kusto_cluster.resource_group_name
   cluster_name        = data.azurerm_kusto_cluster.kusto_cluster.name
   database_name       = azurerm_kusto_database.db[var.domain].name

--- a/src/70_domains/srtp_common/62_dataexplorer.tf
+++ b/src/70_domains/srtp_common/62_dataexplorer.tf
@@ -55,7 +55,7 @@ resource "azurerm_kusto_database_principal_assignment" "rtp_sender_adx_viewer" {
   cluster_name        = data.azurerm_kusto_cluster.kusto_cluster.name
   database_name       = azurerm_kusto_database.db[var.domain].name
 
-  principal_id   = data.azurerm_user_assigned_identity.rtp_sender_workload_identity.principal_id
+  principal_id   = data.azurerm_user_assigned_identity.rtp_sender_workload_identity.client_id
   principal_type = "App"
   tenant_id      = data.azurerm_client_config.current.tenant_id
   role           = "Viewer"

--- a/src/70_domains/srtp_common/99_locals.tf
+++ b/src/70_domains/srtp_common/99_locals.tf
@@ -175,7 +175,8 @@ locals {
   }
 
   # Workload Identity
-  rtp_sender_workload_identity_name = "${local.project}-sender-id"
+  rtp_sender_workload_identity_name    = "${var.domain}-${var.location_short}-workload-identity"
+  rtp_sender_workload_identity_rg_name = local.aks_resource_group_name
 
   ad_group_rbac = flatten([
     var.env_short != "p" ? [


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->just 
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* Fixed ADX access for `rtp-sender` by:

  * pointing to the correct User Assigned Managed Identity (`*-workload-identity`)
  * using `client_id` instead of `principal_id` in Kusto principal assignment
* Aligned principal assignment name to existing resource (`rtp-role-viewer`)

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
ADX queries were failing with `403 Forbidden` because:

* Terraform was referencing the wrong managed identity
* ADX expects the calling identity as `aadapp=<client_id>`, while `principal_id` was used

This caused a mismatch between the identity assigned in ADX and the one actually used by the workload.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
