### PR TITLE
feat: [PAYMCLOUD-837] Add MDC role bindings on Grafana permissions

### DIFF
--- a/src/49_grafanaconf/20_container_logs_dashboard.tf
+++ b/src/49_grafanaconf/20_container_logs_dashboard.tf
@@ -88,6 +88,11 @@ resource "grafana_folder_permission" "admin_permission" {
     permission = "Admin"
   }
   permissions {
+    role       = "Editor"
+    permission = "View"
+  }
+
+  permissions {
     role       = "Viewer"
     permission = "View"
   }

--- a/src/49_grafanaconf/env/itn-dev/terraform.tfvars
+++ b/src/49_grafanaconf/env/itn-dev/terraform.tfvars
@@ -17,8 +17,8 @@ team_groups = {
     "cstar-d-idpay-adgroup-developers" = { permission = "View" }
     "cstar-d-idpay-adgroup-externals"  = { permission = "View" }
     "cstar-d-mdc-adgroup-admin"        = { permission = "Admin" }
-    "cstar-d-mdc-adgroup-developers"   = { permission = "Edit" }
-    "cstar-d-mdc-adgroup-externals"    = { permission = "Edit" }
+    "cstar-d-mdc-adgroup-developers"   = { permission = "View" }
+    "cstar-d-mdc-adgroup-externals"    = { permission = "View" }
   }
   srtp = {
     "cstar-d-srtp-adgroup-admin"      = { permission = "Admin" }

--- a/src/49_grafanaconf/env/itn-dev/terraform.tfvars
+++ b/src/49_grafanaconf/env/itn-dev/terraform.tfvars
@@ -8,37 +8,27 @@ domain                = "platform"
 
 team_groups = {
   idpay = {
-    "cstar-d-idpay-adgroup-admin" = {
-      permission = "Admin"
-    }
-    "cstar-d-idpay-adgroup-developers" = {
-      permission = "Edit"
-    }
-    "cstar-d-idpay-adgroup-externals" = {
-      permission = "Edit"
-    }
+    "cstar-d-idpay-adgroup-admin"      = { permission = "Admin" }
+    "cstar-d-idpay-adgroup-developers" = { permission = "Edit" }
+    "cstar-d-idpay-adgroup-externals"  = { permission = "Edit" }
   }
   keycloak = {
-    "cstar-d-idpay-adgroup-admin" = {
-      permission = "Admin"
-    }
-    "cstar-d-idpay-adgroup-developers" = {
-      permission = "View"
-    }
-    "cstar-d-idpay-adgroup-externals" = {
-      permission = "View"
-    }
+    "cstar-d-idpay-adgroup-admin"      = { permission = "Admin" }
+    "cstar-d-idpay-adgroup-developers" = { permission = "View" }
+    "cstar-d-idpay-adgroup-externals"  = { permission = "View" }
+    "cstar-d-mdc-adgroup-admin"        = { permission = "Admin" }
+    "cstar-d-mdc-adgroup-developers"   = { permission = "Edit" }
+    "cstar-d-mdc-adgroup-externals"    = { permission = "Edit" }
   }
   srtp = {
-    "cstar-d-srtp-adgroup-admin" = {
-      permission = "Admin"
-    }
-    "cstar-d-srtp-adgroup-developers" = {
-      permission = "Edit"
-    }
-    "cstar-d-srtp-adgroup-externals" = {
-      permission = "Edit"
-    }
+    "cstar-d-srtp-adgroup-admin"      = { permission = "Admin" }
+    "cstar-d-srtp-adgroup-developers" = { permission = "Edit" }
+    "cstar-d-srtp-adgroup-externals"  = { permission = "Edit" }
+  }
+  mdc = {
+    "cstar-d-mdc-adgroup-admin"      = { permission = "Admin" }
+    "cstar-d-mdc-adgroup-developers" = { permission = "Edit" }
+    "cstar-d-mdc-adgroup-externals"  = { permission = "Edit" }
   }
 }
 

--- a/src/49_grafanaconf/env/itn-prod/terraform.tfvars
+++ b/src/49_grafanaconf/env/itn-prod/terraform.tfvars
@@ -11,28 +11,35 @@ team_groups = {
     "cstar-p-idpay-adgroup-admin"            = { permission = "Admin" }
     "cstar-p-idpay-adgroup-developers"       = { permission = "View" }
     "cstar-p-idpay-adgroup-externals"        = { permission = "View" }
+    "cstar-p-idpay-adgroup-oncall"           = { permission = "View" }
     "cstar-p-idpay-adgroup-project-managers" = { permission = "View" }
   }
   keycloak = {
     "cstar-p-idpay-adgroup-admin"            = { permission = "Admin" }
     "cstar-p-idpay-adgroup-developers"       = { permission = "View" }
     "cstar-p-idpay-adgroup-externals"        = { permission = "View" }
+    "cstar-p-idpay-adgroup-oncall"           = { permission = "View" }
     "cstar-p-idpay-adgroup-project-managers" = { permission = "View" }
     "cstar-p-mdc-adgroup-admin"              = { permission = "Admin" }
     "cstar-p-mdc-adgroup-developers"         = { permission = "View" }
     "cstar-p-mdc-adgroup-externals"          = { permission = "View" }
     "cstar-p-mdc-adgroup-project-managers"   = { permission = "View" }
+    "cstar-p-mdc-adgroup-oncall"             = { permission = "View" }
   }
   srtp = {
-    "cstar-p-srtp-adgroup-admin"      = { permission = "Admin" }
-    "cstar-p-srtp-adgroup-developers" = { permission = "View" }
-    "cstar-p-srtp-adgroup-externals"  = { permission = "View" }
+    "cstar-p-srtp-adgroup-admin"            = { permission = "Admin" }
+    "cstar-p-srtp-adgroup-developers"       = { permission = "View" }
+    "cstar-p-srtp-adgroup-externals"        = { permission = "View" }
+    "cstar-p-srtp-adgroup-project-managers" = { permission = "View" }
+    "cstar-p-srtp-adgroup-oncall"           = { permission = "View" }
+
   }
   mdc = {
     "cstar-p-mdc-adgroup-admin"            = { permission = "Admin" }
     "cstar-p-mdc-adgroup-developers"       = { permission = "View" }
     "cstar-p-mdc-adgroup-externals"        = { permission = "View" }
     "cstar-p-mdc-adgroup-project-managers" = { permission = "View" }
+    "cstar-p-mdc-adgroup-oncall"           = { permission = "View" }
   }
 }
 

--- a/src/49_grafanaconf/env/itn-prod/terraform.tfvars
+++ b/src/49_grafanaconf/env/itn-prod/terraform.tfvars
@@ -8,50 +8,31 @@ domain                = "platform"
 
 team_groups = {
   idpay = {
-    "cstar-p-idpay-adgroup-admin" = {
-      permission = "Admin"
-    }
-    "cstar-p-idpay-adgroup-developers" = {
-      permission = "View"
-    }
-    "cstar-p-idpay-adgroup-externals" = {
-      permission = "View"
-    }
-    "cstar-p-idpay-adgroup-oncall" = {
-      permission = "View"
-    }
-    "cstar-p-idpay-adgroup-project-managers" = {
-      permission = "View"
-    }
+    "cstar-p-idpay-adgroup-admin"            = { permission = "Admin" }
+    "cstar-p-idpay-adgroup-developers"       = { permission = "View" }
+    "cstar-p-idpay-adgroup-externals"        = { permission = "View" }
+    "cstar-p-idpay-adgroup-project-managers" = { permission = "View" }
   }
   keycloak = {
-    "cstar-p-idpay-adgroup-admin" = {
-      permission = "Admin"
-    }
-    "cstar-p-idpay-adgroup-developers" = {
-      permission = "View"
-    }
-    "cstar-p-idpay-adgroup-externals" = {
-      permission = "View"
-    }
-    "cstar-p-idpay-adgroup-project-managers" = {
-      permission = "View"
-    }
+    "cstar-p-idpay-adgroup-admin"            = { permission = "Admin" }
+    "cstar-p-idpay-adgroup-developers"       = { permission = "View" }
+    "cstar-p-idpay-adgroup-externals"        = { permission = "View" }
+    "cstar-p-idpay-adgroup-project-managers" = { permission = "View" }
+    "cstar-p-mdc-adgroup-admin"              = { permission = "Admin" }
+    "cstar-p-mdc-adgroup-developers"         = { permission = "View" }
+    "cstar-p-mdc-adgroup-externals"          = { permission = "View" }
+    "cstar-p-mdc-adgroup-project-managers"   = { permission = "View" }
   }
-
   srtp = {
-    "cstar-p-srtp-adgroup-admin" = {
-      permission = "Admin"
-    }
-    "cstar-p-srtp-adgroup-developers" = {
-      permission = "View"
-    }
-    "cstar-p-srtp-adgroup-externals" = {
-      permission = "View"
-    }
-    "cstar-p-srtp-adgroup-project-managers" = {
-      permission = "View"
-    }
+    "cstar-p-srtp-adgroup-admin"      = { permission = "Admin" }
+    "cstar-p-srtp-adgroup-developers" = { permission = "View" }
+    "cstar-p-srtp-adgroup-externals"  = { permission = "View" }
+  }
+  mdc = {
+    "cstar-p-mdc-adgroup-admin"            = { permission = "Admin" }
+    "cstar-p-mdc-adgroup-developers"       = { permission = "View" }
+    "cstar-p-mdc-adgroup-externals"        = { permission = "View" }
+    "cstar-p-mdc-adgroup-project-managers" = { permission = "View" }
   }
 }
 

--- a/src/49_grafanaconf/env/itn-uat/terraform.tfvars
+++ b/src/49_grafanaconf/env/itn-uat/terraform.tfvars
@@ -8,37 +8,27 @@ domain                = "platform"
 
 team_groups = {
   idpay = {
-    "cstar-u-idpay-adgroup-admin" = {
-      permission = "Admin"
-    }
-    "cstar-u-idpay-adgroup-developers" = {
-      permission = "View"
-    }
-    "cstar-u-idpay-adgroup-externals" = {
-      permission = "View"
-    }
+    "cstar-u-idpay-adgroup-admin"      = { permission = "Admin" }
+    "cstar-u-idpay-adgroup-developers" = { permission = "View" }
+    "cstar-u-idpay-adgroup-externals"  = { permission = "View" }
   }
   keycloak = {
-    "cstar-u-idpay-adgroup-admin" = {
-      permission = "Admin"
-    }
-    "cstar-u-idpay-adgroup-developers" = {
-      permission = "View"
-    }
-    "cstar-u-idpay-adgroup-externals" = {
-      permission = "View"
-    }
+    "cstar-u-idpay-adgroup-admin"      = { permission = "Admin" }
+    "cstar-u-idpay-adgroup-developers" = { permission = "View" }
+    "cstar-u-idpay-adgroup-externals"  = { permission = "View" }
+    "cstar-u-mdc-adgroup-admin"        = { permission = "Admin" }
+    "cstar-u-mdc-adgroup-developers"   = { permission = "View" }
+    "cstar-u-mdc-adgroup-externals"    = { permission = "View" }
   }
   srtp = {
-    "cstar-u-srtp-adgroup-admin" = {
-      permission = "Admin"
-    }
-    "cstar-u-srtp-adgroup-developers" = {
-      permission = "View"
-    }
-    "cstar-u-srtp-adgroup-externals" = {
-      permission = "View"
-    }
+    "cstar-u-srtp-adgroup-admin"      = { permission = "Admin" }
+    "cstar-u-srtp-adgroup-developers" = { permission = "View" }
+    "cstar-u-srtp-adgroup-externals"  = { permission = "View" }
+  }
+  mdc = {
+    "cstar-u-mdc-adgroup-admin"      = { permission = "Admin" }
+    "cstar-u-mdc-adgroup-developers" = { permission = "View" }
+    "cstar-u-mdc-adgroup-externals"  = { permission = "View" }
   }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Added MDC Keycloak role bindings for ITN-DEV, ITN-UAT, and ITN-PROD environments.
- Adjusted Grafana dashboard permissions for Editors to include “View” access.
- Consolidated and formatted `team_groups` configurations across all environments.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
