### PR TITLE
feat: [SRTP-1744] add new table RtpsStaging on azure data explorer

### DIFF
--- a/src/70_domains/srtp_common/data_explorer_kql/create_tables_srtp.kql
+++ b/src/70_domains/srtp_common/data_explorer_kql/create_tables_srtp.kql
@@ -31,3 +31,27 @@
     precStatus: string,
     triggerEvent: string
 )
+
+.create-merge table RtpsStaging (
+    _idRaw: string,
+    noticeNumber: string,
+    amount: decimal,
+    description: string,
+    expiryDateMs: long,
+    payerName: string,
+    payerId: string,
+    payeeName: string,
+    payeeId: string,
+    subject: string,
+    savingDateTimeMs: long,
+    serviceProviderDebtor: string,
+    iban: string,
+    payTrxRef: string,
+    flgConf: string,
+    status: string,
+    serviceProviderCreditor: string,
+    operationId: long,
+    eventDispatcher: string,
+    operationDispatcherKey: string,
+    eventsRaw: string
+)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
* Added a new table `RtpsStaging` in Azure Data Explorer.
* Configured the table using `.create-merge` to ensure idempotent deployment.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change introduces a new staging table required for Azure Data Factory pipelines.

The table is needed to:

* Store intermediate RTPS data ingested through ADF
* Enable downstream processing and transformations

Without this table, the ADF pipeline would not have a proper destination for staging incoming data.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
