### PR TITLE
feat: [SRTP-1653] Add 'payee' database in SRTP Cosmos Account

### DIFF
--- a/src/70_domains/srtp_common/99_locals.tf
+++ b/src/70_domains/srtp_common/99_locals.tf
@@ -155,7 +155,7 @@ locals {
           default_ttl_seconds               = -1
           indexes = [
             {
-              keys = ["_id"]
+              keys   = ["_id"]
               unique = true
             }
           ]

--- a/src/70_domains/srtp_common/99_locals.tf
+++ b/src/70_domains/srtp_common/99_locals.tf
@@ -145,6 +145,23 @@ locals {
         }
       }
     }
+    payee = {
+      # Database-level throughput: RU are shared across all collections
+      db_autoscale_max_throughput = var.cosmos_payee_db_autoscale_max_throughput
+      collections = {
+        payees = {
+          autoscale_max_throughput          = null
+          cosmos_collections_max_throughput = null
+          default_ttl_seconds               = -1
+          indexes = [
+            {
+              keys = ["_id"]
+              unique = true
+            }
+          ]
+        }
+      }
+    }
   }
   cosmos_collections = flatten([
     for db_name, db in local.cosmos_db : [

--- a/src/70_domains/srtp_common/99_variables.tf
+++ b/src/70_domains/srtp_common/99_variables.tf
@@ -96,6 +96,12 @@ variable "cosmos_rtp_db_autoscale_max_throughput" {
   default     = null
 }
 
+variable "cosmos_payee_db_autoscale_max_throughput" {
+  type        = number
+  description = "Max throughput for payee database (shared across collections)"
+  default     = null
+}
+
 variable "cosmos_otp_ttl" {
   type        = number
   description = "TTL for otps collection."

--- a/src/70_domains/srtp_common/README.md
+++ b/src/70_domains/srtp_common/README.md
@@ -173,6 +173,7 @@
 | <a name="input_cosmos_activation_db_autoscale_max_throughput"></a> [cosmos\_activation\_db\_autoscale\_max\_throughput](#input\_cosmos\_activation\_db\_autoscale\_max\_throughput) | Max throughput for activation database (shared across collections) | `number` | `null` | no |
 | <a name="input_cosmos_collections_max_throughput"></a> [cosmos\_collections\_max\_throughput](#input\_cosmos\_collections\_max\_throughput) | Max throughput for collections | `number` | `null` | no |
 | <a name="input_cosmos_otp_ttl"></a> [cosmos\_otp\_ttl](#input\_cosmos\_otp\_ttl) | TTL for otps collection. | `number` | `null` | no |
+| <a name="input_cosmos_payee_db_autoscale_max_throughput"></a> [cosmos\_payee\_db\_autoscale\_max\_throughput](#input\_cosmos\_payee\_db\_autoscale\_max\_throughput) | Max throughput for payee database (shared across collections) | `number` | `null` | no |
 | <a name="input_cosmos_rtp_db_autoscale_max_throughput"></a> [cosmos\_rtp\_db\_autoscale\_max\_throughput](#input\_cosmos\_rtp\_db\_autoscale\_max\_throughput) | Max throughput for rtp database (shared across collections) | `number` | `null` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | n/a | yes |
 | <a name="input_enable_cdn"></a> [enable\_cdn](#input\_enable\_cdn) | Enable CDN for the domain | `bool` | n/a | yes |

--- a/src/70_domains/srtp_common/env/itn-prod/terraform.tfvars
+++ b/src/70_domains/srtp_common/env/itn-prod/terraform.tfvars
@@ -18,6 +18,9 @@ cosmos_activation_db_autoscale_max_throughput = 20000
 # RTP database - shared throughput at database level (1000 RU)
 cosmos_rtp_db_autoscale_max_throughput = 10000
 
+# Payee database - shared throughput at database level
+cosmos_payee_db_autoscale_max_throughput = 1000
+
 cosmos_otp_ttl = 3600
 
 # AKS

--- a/src/70_domains/srtp_common/env/itn-uat/terraform.tfvars
+++ b/src/70_domains/srtp_common/env/itn-uat/terraform.tfvars
@@ -19,6 +19,9 @@ cosmos_activation_db_autoscale_max_throughput = 4000
 # RTP database - shared throughput at database level (1000 RU)
 cosmos_rtp_db_autoscale_max_throughput = 1000
 
+# Payee database - shared throughput at database level
+cosmos_payee_db_autoscale_max_throughput = 1000
+
 cosmos_otp_ttl = 3600
 
 # AKS


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Added a new CosmosDB Mongo database `payee`;
- Added a new `payees` collection inside the `payee` database;
- Set `cosmos_payee_db_autoscale_max_throughput = 1000` RU in both `itn-uat` and `itn-prod` tfvars

### Motivation and context

These new additions allow _Payees_ domain to store relevant data and documents.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
This PR has been partially applied because, during `terraform apply`, there errors concerning the migration of the _CDN_.
None of those error nor the impacted resources overlap with the developments of this PR.