### PR TITLE
fix: [SRTP-1757] remove unused RtpsStaging table from Azure Data Explorer

### DIFF
--- a/src/70_domains/srtp_common/README.md
+++ b/src/70_domains/srtp_common/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10.0 |
 | <a name="requirement_argocd"></a> [argocd](#requirement\_argocd) | ~> 7.0 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 2.0 |
@@ -16,7 +16,7 @@
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_argocd"></a> [argocd](#provider\_argocd) | 7.15.3 |
 | <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 2.9.0 |
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.53.1 |
@@ -28,7 +28,7 @@
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | a8f4c9f446b46bfec080b1f39206dd29e2975b95 |
 | <a name="module_aks_overlay_snet"></a> [aks\_overlay\_snet](#module\_aks\_overlay\_snet) | ./.terraform/modules/__v4__/IDH/subnet | n/a |
 | <a name="module_aks_srtp_node_pool_blue"></a> [aks\_srtp\_node\_pool\_blue](#module\_aks\_srtp\_node\_pool\_blue) | ./.terraform/modules/__v4__/IDH/aks_node_pool | n/a |
@@ -50,7 +50,7 @@
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [argocd_project.domain_project](https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/project) | resource |
 | [azapi_resource.create_tables_srtp](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) | resource |
 | [azapi_resource_action.cosmos_approve_pe](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource_action) | resource |
@@ -165,7 +165,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_geo_locations"></a> [additional\_geo\_locations](#input\_additional\_geo\_locations) | Specifies a list of additional geo\_location resources, used to define where data should be replicated. | <pre>list(object({<br/>    location          = string<br/>    failover_priority = number<br/>    zone_redundant    = bool<br/>  }))</pre> | `[]` | no |
 | <a name="input_aks_nodepool_blue"></a> [aks\_nodepool\_blue](#input\_aks\_nodepool\_blue) | Parameters for blue node pool | <pre>object({<br/>    vm_sku_name       = string<br/>    autoscale_enabled = optional(bool, true)<br/>    node_count_min    = number<br/>    node_count_max    = number<br/>  })</pre> | n/a | yes |
 | <a name="input_aks_nodepool_green"></a> [aks\_nodepool\_green](#input\_aks\_nodepool\_green) | Parameters for green node pool | <pre>object({<br/>    vm_sku_name       = string<br/>    autoscale_enabled = optional(bool, true)<br/>    node_count_min    = number<br/>    node_count_max    = number<br/>  })</pre> | n/a | yes |

--- a/src/70_domains/srtp_common/data_explorer_kql/create_tables_srtp.kql
+++ b/src/70_domains/srtp_common/data_explorer_kql/create_tables_srtp.kql
@@ -31,27 +31,3 @@
     precStatus: string,
     triggerEvent: string
 )
-
-.create-merge table RtpsStaging (
-    _idRaw: string,
-    noticeNumber: string,
-    amount: decimal,
-    description: string,
-    expiryDateMs: long,
-    payerName: string,
-    payerId: string,
-    payeeName: string,
-    payeeId: string,
-    subject: string,
-    savingDateTimeMs: long,
-    serviceProviderDebtor: string,
-    iban: string,
-    payTrxRef: string,
-    flgConf: string,
-    status: string,
-    serviceProviderCreditor: string,
-    operationId: long,
-    eventDispatcher: string,
-    operationDispatcherKey: string,
-    eventsRaw: string
-)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

* Removed the `RtpsStaging` table from Azure Data Explorer.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

The `RtpsStaging` table was originally introduced to support an Azure Data Factory pipeline. This table is no longer required as the related functionality has been deprecated/removed.

Keeping unused resources increases maintenance overhead and can lead to confusion, so this change cleans up obsolete infrastructure.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [x] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
