### PR TITLE
feat: [SRTP-1762] update workbook OER

### DIFF
--- a/src/70_domains/srtp_common/.terraform.lock.hcl
+++ b/src/70_domains/srtp_common/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/argoproj-labs/argocd" {
   constraints = "~> 7.0"
   hashes = [
     "h1:gklxppttVJ+pXqxAkUwmQFR9EreSKNBqoh7hbLbyIPI=",
+    "h1:ugsethfDCkqJz/qafebB3qFsMN3lYoektBVD30tl6mg=",
     "zh:1a754d97259b9d2e9e624703eec655278bff20ca829b9d48ee9aae9591af2681",
     "zh:3728ed3654f426d745d624d6895631651ebd8e84d594fe475849f2ad02c5c027",
     "zh:4261e504831d8744de39e583a3b6931ced1ca6b67b2363448243197548cb6fd1",
@@ -23,6 +24,7 @@ provider "registry.terraform.io/azure/azapi" {
   version     = "2.9.0"
   constraints = "~> 2.0"
   hashes = [
+    "h1:XtiXcDMV+sEfQFcRot9fwKF/Y0aXeho9A/WVfHdHwCc=",
     "h1:ivmN39jnMJRZXlPuX8r5TTXM8lyF8ZocPQQgEUy61eM=",
     "zh:0a4eee8c9362db6ca19d371eccf38701c8306be761182da87b624294f7e8f867",
     "zh:4df87bee5b8f4cce27461ae26132a599542583cdf035942b42b0259a514ab46e",
@@ -43,6 +45,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version     = "2.53.1"
   constraints = "~> 2.53"
   hashes = [
+    "h1:2rk36pu4YyhBVz/Mf4swYCQxaB31iPaXOiWNlqZMXbM=",
     "h1:EZNO8sEtUABuRxujQrDrW1z1QsG0dq6iLbzWtnG7Om4=",
     "zh:162916b037e5133f49298b0ffa3e7dcef7d76530a8ca738e7293373980f73c68",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
@@ -63,6 +66,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.69.0"
   constraints = "~> 4.0"
   hashes = [
+    "h1:7/xobNJsmzrSRDhlopc322Ro4l8qG6ElxGJpGWW4V3g=",
     "h1:v3FxvKYMLI4vcIoci76swAvTcxR72gXlvtAaztqra5A=",
     "zh:2bdbbfea89ad95bc2f620a41aecde5ff32a9406fa7c994028be5486e6d16e8f4",
     "zh:382971e3b41337ff87eebaa76c070aec6815fcf9c0d29eb4c3049c7a28d5c288",
@@ -83,6 +87,7 @@ provider "registry.terraform.io/hashicorp/external" {
   version     = "2.3.5"
   constraints = "~> 2.3"
   hashes = [
+    "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
     "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -103,6 +108,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.38.0"
   constraints = "~> 2.0, ~> 2.27, ~> 2.30, ~> 2.36"
   hashes = [
+    "h1:7nJdsd1RMPBtOjDXidB37+KSDN5VcOWkbkow69qJVGc=",
     "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
     "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
     "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
@@ -123,6 +129,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.4"
   constraints = "~> 3.2"
   hashes = [
+    "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
     "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -143,6 +150,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.8.1"
   constraints = "~> 3.0"
   hashes = [
+    "h1:fdfOl1HabDT42XLH8qjmfTbVZpgQZ5lyOyOa+GQhm0w=",
     "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
@@ -164,6 +172,7 @@ provider "registry.terraform.io/keycloak/keycloak" {
   constraints = ">= 5.0.0"
   hashes = [
     "h1:3DuKdVeOxwULh7l6bvJKWZvsgSZo92rtnrdvyp+X2Lc=",
+    "h1:NirXBuj9KGkWA/QUtWPMWUPZE0lbkpvnGRa7guuRo6Q=",
     "zh:19be4505b17e4818db121a82917cb6723019cf379cfb82b720eaa2886f15bede",
     "zh:2bd1565ed22db6a9fb50d60626e22c277f3b034a71f65e6c0011e42f56cad2bb",
     "zh:34a9e2dfb06331dc6146491c4a0721001195c6a769cdc2d4546edb2acf2b39bd",

--- a/src/70_domains/srtp_common/13_workbooks.tf
+++ b/src/70_domains/srtp_common/13_workbooks.tf
@@ -44,6 +44,10 @@ locals {
       name     = "Cancellazioni RTP (API)"
       filePath = "${path.module}/workbooks/tabs/cancellazioneAPI.json.tpl"
     },
+    {
+      name     = "Accessi Get Enti"
+      filePath = "${path.module}/workbooks/tabs/getPayees.json.tpl"
+    },
   ]
 
   workbook_items = join(",", [

--- a/src/70_domains/srtp_common/workbooks/tabs/activator.json.tpl
+++ b/src/70_domains/srtp_common/workbooks/tabs/activator.json.tpl
@@ -108,8 +108,8 @@
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-monitor-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-law",
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law",
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-monitor-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-law"
                 ],
                 "visualization": "piechart",
                 "chartSettings": {
@@ -272,8 +272,8 @@
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-monitor-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-law",
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law",
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-monitor-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-law"
                 ],
                 "visualization": "unstackedbar",
                 "chartSettings": {
@@ -332,7 +332,7 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == \"rtp-activator\"\n| where TimeGenerated {evaluation_window:query}\n| where Message hasprefix \"Error during activation process Authenticated user doesn't have permission to perform this action\"\n| extend tokenSpId = extract(@\"tokenSpId:\\s*([^\\s]+)\", 1, Message)\n| extend props = todynamic(Properties)\n| extend serviceProvider = tostring(props[\"service_provider\"])\n| where isnotempty(tokenSpId) and isnotempty(serviceProvider)\n| summarize\n    ['Error Count'] = count(),\n    ['Service Providers'] = make_set(serviceProvider, 100)\n  by ['Token SP ID'] = tostring(tokenSpId)\n| order by ['Error Count'] desc\n",
+                "query": "AppTraces\n| where AppRoleName == \"rtp-activator\"\n| where TimeGenerated {evaluation_window:query}\n| where Message has \"Error during activation process for SP\"\n    and Message has \"Authenticated user doesn't have permission to perform this action\"\n| extend props = todynamic(Properties)\n| extend tokenSpId = tostring(props[\"sub_token\"])\n| extend spId = extract(@\"Error during activation process for SP\\s+([^:]+):\", 1, Message)\n| summarize\n    ['Error Count'] = count(),\n    ['SP IDs (from request)'] = make_set(spId, 100)\n  by ['Token SP ID'] = tokenSpId\n| order by ['Error Count'] desc",
                 "size": 1,
                 "title": "❌ Mismatch del Service Provider tra Token e Body",
                 "noDataMessageStyle": 3,

--- a/src/70_domains/srtp_common/workbooks/tabs/activator.json.tpl
+++ b/src/70_domains/srtp_common/workbooks/tabs/activator.json.tpl
@@ -332,7 +332,7 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == \"rtp-activator\"\n| where TimeGenerated {evaluation_window:query}\n| where Message has \"Error during activation process for SP\"\n    and Message has \"Authenticated user doesn't have permission to perform this action\"\n| extend props = todynamic(Properties)\n| extend tokenSpId = tostring(props[\"sub_token\"])\n| extend spId = extract(@\"Error during activation process for SP\\s+([^:]+):\", 1, Message)\n| summarize\n    ['Error Count'] = count(),\n    ['SP IDs (from request)'] = make_set(spId, 100)\n  by ['Token SP ID'] = tokenSpId\n| order by ['Error Count'] desc",
+                "query": "AppTraces\n| where AppRoleName == \"rtp-activator\"\n| where TimeGenerated {evaluation_window:query}\n| where Message has \"Error during activation process for SP\"\n    and Message has \"Authenticated user doesn't have permission to perform this action\"\n| extend props = todynamic(Properties)\n| extend tokenSpId = tostring(props[\"sub_token\"])\n| extend spId = extract(@\"Error during activation process for SP\\s+([^:]+):\", 1, Message)\n| where isnotempty(tokenSpId)\n| where isnotempty(spId)\n| summarize\n    ['Error Count'] = count(),\n    ['SP IDs (from request)'] = make_set(spId, 100)\n  by ['Token SP ID'] = tokenSpId\n| order by ['Error Count'] desc",
                 "size": 1,
                 "title": "❌ Mismatch del Service Provider tra Token e Body",
                 "noDataMessageStyle": 3,

--- a/src/70_domains/srtp_common/workbooks/tabs/autenticazione.json.tpl
+++ b/src/70_domains/srtp_common/workbooks/tabs/autenticazione.json.tpl
@@ -11,7 +11,7 @@
           "version": "KqlItem/1.0",
           "query": "AppMetrics\n| where TimeGenerated {evaluation_window:query}\n| where Name startswith \"keycloak_user\"\n| extend\n    realm     = tostring(Properties[\"realm\"]),\n    client_id = tostring(Properties[\"client_id\"]),\n    event     = tostring(Properties[\"event\"]),\n    error     = tostring(Properties[\"error\"])\n| where realm == \"srtp\"\n| summarize\n    ['Token emessi']     = sum(ItemCount),\n    ['Ultima emissione'] = max(TimeGenerated),\n    ['Prima emissione']  = min(TimeGenerated)\n    by client_id, event, error\n| extend\n    ['Ultima emissione'] = format_datetime(['Ultima emissione'], \"yyyy-MM-dd HH:mm:ss\"),\n    ['Prima emissione']  = format_datetime(['Prima emissione'],  \"yyyy-MM-dd HH:mm:ss\")\n| order by ['Token emessi'] desc\n| project\n    ['Client ID']    = client_id,\n    ['Evento']       = event,\n    ['Errore']       = iff(error == \"\", \"-\", error),\n    ['Token emessi'],\n    ['Prima emissione'],\n    ['Ultima emissione']\n",
           "size": 0,
-          "title": "Panoramica stacco del token (Metriche Keycloak) ",
+          "title": "Panoramica stacco del token (Metriche Keycloak)",
           "timeContextFromParameter": "evaluation_window",
           "queryType": 0,
           "resourceType": "microsoft.operationalinsights/workspaces",

--- a/src/70_domains/srtp_common/workbooks/tabs/autenticazione.json.tpl
+++ b/src/70_domains/srtp_common/workbooks/tabs/autenticazione.json.tpl
@@ -9,6 +9,22 @@
         "type": 3,
         "content": {
           "version": "KqlItem/1.0",
+          "query": "AppMetrics\n| where TimeGenerated {evaluation_window:query}\n| where Name startswith \"keycloak_user\"\n| extend\n    realm     = tostring(Properties[\"realm\"]),\n    client_id = tostring(Properties[\"client_id\"]),\n    event     = tostring(Properties[\"event\"]),\n    error     = tostring(Properties[\"error\"])\n| where realm == \"srtp\"\n| summarize\n    ['Token emessi']     = sum(ItemCount),\n    ['Ultima emissione'] = max(TimeGenerated),\n    ['Prima emissione']  = min(TimeGenerated)\n    by client_id, event, error\n| extend\n    ['Ultima emissione'] = format_datetime(['Ultima emissione'], \"yyyy-MM-dd HH:mm:ss\"),\n    ['Prima emissione']  = format_datetime(['Prima emissione'],  \"yyyy-MM-dd HH:mm:ss\")\n| order by ['Token emessi'] desc\n| project\n    ['Client ID']    = client_id,\n    ['Evento']       = event,\n    ['Errore']       = iff(error == \"\", \"-\", error),\n    ['Token emessi'],\n    ['Prima emissione'],\n    ['Ultima emissione']\n",
+          "size": 0,
+          "title": "Panoramica stacco del token (Metriche Keycloak) ",
+          "timeContextFromParameter": "evaluation_window",
+          "queryType": 0,
+          "resourceType": "microsoft.operationalinsights/workspaces",
+          "crossComponentResources": [
+            "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-core-monitor-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-core-law"
+          ]
+        },
+        "name": "query - 1"
+      },
+      {
+        "type": 3,
+        "content": {
+          "version": "KqlItem/1.0",
           "query": "ApiManagementGatewayLogs\n| where TimeGenerated {evaluation_window:query}\n| where ApiId == \"${prefix}-${env_short}-${location_short}-mcshared-auth\"\n| where isnotempty(TraceRecords)\n| mv-expand trace = parse_json(TraceRecords)\n| where trace.source == \"KeycloakTokenIssued\"\n| extend\n    client_id   = tostring(trace.metadata.client_id),\n    sub         = tostring(trace.metadata.sub),\n    duration_ms = TotalTime\n| summarize\n    ['Token emessi']      = count(),\n    ['Ultima emissione']  = max(TimeGenerated),\n    ['Prima emissione']   = min(TimeGenerated),\n    ['Latenza media (ms)'] = round(avg(duration_ms), 0)\n    by client_id, sub\n| extend\n    ['Ultima emissione'] = format_datetime(['Ultima emissione'], \"yyyy-MM-dd HH:mm:ss\"),\n    ['Prima emissione']  = format_datetime(['Prima emissione'],  \"yyyy-MM-dd HH:mm:ss\")\n| order by ['Token emessi'] desc\n| project\n    ['Client ID']          = client_id,\n    ['Soggetto (sub)']     = sub,\n    ['Token emessi'],\n    ['Latenza media (ms)'],\n    ['Prima emissione'],\n    ['Ultima emissione']\n",
           "size": 0,
           "title": "Panoramica stacco del token (Keycloak)",

--- a/src/70_domains/srtp_common/workbooks/tabs/getPayees.json.tpl
+++ b/src/70_domains/srtp_common/workbooks/tabs/getPayees.json.tpl
@@ -42,7 +42,7 @@
           "version": "KqlItem/1.0",
           "query": "let deps =\n    AppDependencies\n    | where TimeGenerated {evaluation_window:query}\n    | where Name startswith \"GET\" and Name contains \"/rtppayees\"\n    | extend JWT_Subject = tostring(Properties[\"Request-X-JWT-Subject\"])\n    | where isnotempty(JWT_Subject)\n    | summarize JWT_Subject = any(JWT_Subject) by OperationId;\n\nAppRequests\n| where TimeGenerated {evaluation_window:query}\n| where AppRoleName == \"rtp-payees\"\n| where Name == \"GET /\"\n| where ResultCode != \"200\"\n| project OperationId, ResultCode\n| join kind=leftouter deps on OperationId\n| extend JWT_Subject = iif(isempty(JWT_Subject), \"UNKNOWN\", JWT_Subject)\n| extend Label = strcat(JWT_Subject, \" (\", ResultCode, \")\")\n| summarize NumeroEventi = count() by Label\n| extend Label = strcat(Label, \" — \", NumeroEventi)\n| project Label, NumeroEventi",
           "size": 0,
-          "title": "✅  Accessi per Subject alla get payees",
+          "title": "✅ Accessi per Subject alla get payees",
           "queryType": 0,
           "resourceType": "microsoft.operationalinsights/workspaces",
           "crossComponentResources": [
@@ -50,7 +50,7 @@
           ]
         },
         "customWidth": "50",
-        "name": "✅  Accessi per Subject alla get payees",
+        "name": "✅ Accessi per Subject alla get payees",
         "styleSettings": {
           "showBorder": true
         }

--- a/src/70_domains/srtp_common/workbooks/tabs/getPayees.json.tpl
+++ b/src/70_domains/srtp_common/workbooks/tabs/getPayees.json.tpl
@@ -1,0 +1,92 @@
+{
+  "type": 12,
+  "content": {
+    "version": "NotebookGroup/1.0",
+    "groupType": "editable",
+    "title": "Get Enti",
+    "items": [
+      {
+        "type": 3,
+        "content": {
+          "version": "KqlItem/1.0",
+          "query": "AzureDiagnostics\n| where TimeGenerated {evaluation_window:query}\n| where requestUri_s contains 'rtp/payees/consents'\n| summarize Count = count() by StatusCode = tostring(toint(httpStatus_d))\n| render piechart\n",
+          "size": 0,
+          "title": "Panoramica degli accessi totali al Payees Consents con status code",
+          "queryType": 0,
+          "resourceType": "microsoft.operationalinsights/workspaces",
+          "crossComponentResources": [
+            "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-monitor-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-law"
+          ],
+          "visualization": "piechart",
+          "chartSettings": {
+            "ySettings": {
+              "numberFormatSettings": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": true
+                }
+              }
+            }
+          }
+        },
+        "customWidth": "50",
+        "name": "Panoramica degli accessi totali al Payees Consents con status code",
+        "styleSettings": {
+          "showBorder": true
+        }
+      },
+      {
+        "type": 3,
+        "content": {
+          "version": "KqlItem/1.0",
+          "query": "let deps =\n    AppDependencies\n    | where TimeGenerated {evaluation_window:query}\n    | where Name startswith \"GET\" and Name contains \"/rtppayees\"\n    | extend JWT_Subject = tostring(Properties[\"Request-X-JWT-Subject\"])\n    | where isnotempty(JWT_Subject)\n    | summarize JWT_Subject = any(JWT_Subject) by OperationId;\n\nAppRequests\n| where TimeGenerated {evaluation_window:query}\n| where AppRoleName == \"rtp-payees\"\n| where Name == \"GET /\"\n| where ResultCode != \"200\"\n| project OperationId, ResultCode\n| join kind=leftouter deps on OperationId\n| extend JWT_Subject = iif(isempty(JWT_Subject), \"UNKNOWN\", JWT_Subject)\n| extend Label = strcat(JWT_Subject, \" (\", ResultCode, \")\")\n| summarize NumeroEventi = count() by Label\n| extend Label = strcat(Label, \" — \", NumeroEventi)\n| project Label, NumeroEventi",
+          "size": 0,
+          "title": "✅  Accessi per Subject alla get payees",
+          "queryType": 0,
+          "resourceType": "microsoft.operationalinsights/workspaces",
+          "crossComponentResources": [
+            "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+          ]
+        },
+        "customWidth": "50",
+        "name": "✅  Accessi per Subject alla get payees",
+        "styleSettings": {
+          "showBorder": true
+        }
+      },
+      {
+        "type": 3,
+        "content": {
+          "version": "KqlItem/1.0",
+          "query": "AzureDiagnostics\n| where TimeGenerated {evaluation_window:query}\n| where requestUri_s contains 'rtp/payees/consents'\n| summarize \n    Successo   = countif(httpStatus_d == 200),\n    Fallimento = countif(httpStatus_d != 200)\n  by bin(TimeGenerated, 1h)\n| project TimeGenerated, Successo, Fallimento\n| render timechart\n",
+          "size": 0,
+          "title": "Accessi al Payees Consents (Successi vs Fallimenti) in bin 1 ora",
+          "queryType": 0,
+          "resourceType": "microsoft.operationalinsights/workspaces",
+          "crossComponentResources": [
+            "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-monitor-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-law"
+          ],
+          "chartSettings": {
+            "ySettings": {
+              "numberFormatSettings": {
+                "unit": 0,
+                "options": {
+                  "style": "decimal",
+                  "useGrouping": true
+                }
+              }
+            }
+          }
+        },
+        "name": "Accessi al Payees Consents (Successi vs Fallimenti) in bin 1 ora"
+      }
+    ]
+  },
+  "conditionalVisibility": {
+    "parameterName": "tab",
+    "comparison": "isEqualTo",
+    "value": "getPayees"
+  },
+  "name": "Get Enti"
+}

--- a/src/70_domains/srtp_common/workbooks/tabs/invii-srtp.json.tpl
+++ b/src/70_domains/srtp_common/workbooks/tabs/invii-srtp.json.tpl
@@ -578,7 +578,7 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-consumer'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Retries exhausted after attempts\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-consumer'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Retries exhausted after attempts\"\n| extend retry_msg_id = extract(@\"message_id:\\s*(\\d+)\", 1, Message)\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
                 "size": 0,
                 "title": "❌ Retry esauriti Consumer → Sender",
                 "noDataMessageStyle": 3,
@@ -609,6 +609,40 @@
               "styleSettings": {
                 "showBorder": true
               }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "let payloads = AppTraces\n| where AppRoleName == 'rtp-consumer'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Payload:\"\n| extend\n    msg_id          = extract(@\"id=(\\d+)\", 1, Message),\n    operation       = extract(@\"operation=(\\w+)\", 1, Message),\n    status          = extract(@\"status=([A-Z_]+)\", 1, Message),\n    ec_tax_code     = extract(@\"ec_tax_code=([^,\\]]+)\", 1, Message),\n    debtor_tax_code = extract(@\"debtor_tax_code=([^,\\]]+)\", 1, Message),\n    iuv             = extract(@\"iuv=([^,\\]]+)\", 1, Message)\n| where isnotempty(msg_id);\nlet retries_exhausted = AppTraces\n| where AppRoleName == 'rtp-consumer'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Retries exhausted after attempts\"\n| extend\n    msg_id   = extract(@\"message_id:\\s*(\\d+)\", 1, Message),\n    attempts = extract(@\"attempts:\\s*(\\d+)\", 1, Message);\nlet errors = AppTraces\n| where AppRoleName == 'rtp-consumer'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error providing message to rtp-sender\"\n| extend\n    msg_id    = tostring(Properties.message_id),\n    error_msg = extract(@\"message='([^']+)'\", 1, Message);\nretries_exhausted\n| join kind=leftouter payloads on msg_id\n| join kind=leftouter errors on msg_id\n| project\n    [\"Data\"]            = TimeGenerated,\n    [\"Message ID\"]      = msg_id,\n    [\"Tentativi\"]       = attempts,\n    [\"Operazione\"]      = operation,\n    [\"Status GPD\"]      = status,\n    [\"EC Tax Code\"]     = ec_tax_code,\n    [\"Debtor Tax Code\"] = debtor_tax_code,\n    [\"IUV\"]             = iuv,\n    [\"Errore\"]          = error_msg\n| sort by [\"Data\"] desc\n| limit 50",
+                "size": 0,
+                "title": "❌ Retry esauriti Consumer → Sender",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "statSettings": {
+                  "valueField": "totalRequestsString",
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
+              },
+              "name": "❌ Retry esauriti Consumer → Sender - Copy",
+              "styleSettings": {
+                "showBorder": true
+              }
             }
           ]
         },
@@ -629,585 +663,7 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Message processed successfully, rtp created with id\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
-                "size": 0,
-                "title": "✅ Messaggi ricevuti dal Sender tramite Consumer",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "stat",
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
-              },
-              "customWidth": "25",
-              "name": "Messaggi inviati da Consumer a Sender",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error while processing GPD message for requestId\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
-                "size": 0,
-                "title": "❌ Fallimenti ricezione messaggi Sender da Consumer",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "stat",
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
-              },
-              "customWidth": "25",
-              "name": "Messaggi falliti da Consumer a Sender - Copy",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Rtp sent successfully with id:\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
-                "size": 0,
-                "title": "✅ Invii totali con successo (APIM + CODA)",
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "stat",
-                "statSettings": {
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "numberFormatSettings": {
-                    "unit": 0,
-                    "options": {
-                      "style": "decimal"
-                    }
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
-              },
-              "customWidth": "25",
-              "name": "✅ Invii totali con successo (APIM + CODA)",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error finding activation data with resourceId:\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
-                "size": 0,
-                "title": "❌ RTP non creato - attivazione inesistente per il Codice Fiscale",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "stat",
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
-              },
-              "customWidth": "25",
-              "name": "❌ Invii falliti (Servizio)",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error saving Rtp to be sent:\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
-                "size": 0,
-                "title": "❌ Errore nel salvataggio a DB del RTP",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "stat",
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
-              },
-              "customWidth": "25",
-              "name": "❌ Invii falliti (Servizio) - Copy",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error sending Rtp to be sent:\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
-                "size": 0,
-                "title": "❌ Errore nell'invio del RTP",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "stat",
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
-              },
-              "customWidth": "25",
-              "name": "❌ Invii falliti (Servizio) - Copy - Copy",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Send RTP request rejected for\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
-                "size": 0,
-                "title": "❌ RTP rifiutati dal Service Provider",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "stat",
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
-              },
-              "customWidth": "25",
-              "name": "❌ RTP rifiutati dal Service Provider",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"An unexpected error occurred while sending RTP\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
-                "size": 0,
-                "title": "❌ Errori inattesi nell'invio",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "stat",
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
-              },
-              "customWidth": "25",
-              "name": "❌ Errori inattesi nell'invio",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error retrieving registry data\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
-                "size": 0,
-                "title": "❌ Errori Registry Service Provider",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "stat",
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
-              },
-              "customWidth": "25",
-              "name": "❌ Errori Registry Service Provider",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error while getting Payees list\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
-                "size": 0,
-                "title": "❌ Errori Payee Registry",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "stat",
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
-              },
-              "customWidth": "25",
-              "name": "❌ Errori Payee Registry",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error sending Rtp to be sent:\"\n| extend _err = trim(\" \", replace_string(Message, \"Error sending Rtp to be sent:\", \"\"))\n| extend Categoria = case(\n    _err contains \"payer is not activated\",              \"Payer non attivato\",\n    _err contains \"rejected\" or _err contains \"Reject\",  \"Rejection SEPA\",\n    _err contains \"imout\" or _err contains \"Timeout\",    \"Timeout\",\n    _err contains \"Connection\" or _err contains \"refused\",\"Errore di rete\",\n    _err contains \"MongoWrite\" or _err contains \"Mongo\",  \"Errore DB Mongo\",\n    \"Altro / non classificato\"\n)\n| summarize Errori = count() by Categoria\n| sort by Errori desc",
-                "size": 0,
-                "title": "Classificazione errori di invio per tipo",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "piechart"
-              },
-              "customWidth": "50",
-              "name": "Classificazione errori di invio per tipo",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppExceptions\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| summarize\n    [\"Occorrenze\"] = count(),\n    [\"Ultimo messaggio\"] = arg_max(TimeGenerated, OuterMessage)\n    by [\"Tipo eccezione\"] = ExceptionType\n| sort by [\"Occorrenze\"] desc",
-                "size": 0,
-                "title": "Eccezioni Java rtp-sender (AppExceptions)",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "table"
-              },
-              "customWidth": "100",
-              "name": "Eccezioni Java rtp-sender (AppExceptions)",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Send RTP request rejected for\"\n| extend\n    service_provider = extract(@\"Send RTP request rejected for (\\S+):\", 1, Message),\n    rejection_reason = extract(@\"Send RTP request rejected for \\S+: (.+)$\", 1, Message)\n| summarize\n    [\"Rifiuti\"] = count(),\n    [\"Ultimo motivo\"] = arg_max(TimeGenerated, rejection_reason)\n    by [\"Service Provider\"] = service_provider\n| sort by [\"Rifiuti\"] desc",
-                "size": 0,
-                "title": "❌ RTP rifiutati per Service Provider (dettaglio)",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "table"
-              },
-              "customWidth": "50",
-              "name": "❌ RTP rifiutati per Service Provider (dettaglio)",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"An unexpected error occurred while sending RTP\"\n| extend\n    service_provider = tostring(Properties.serviceProviderDebtor),\n    error_msg = extract(@\"Error: (.+)$\", 1, Message)\n| summarize\n    [\"Errori\"] = count(),\n    [\"Ultimo errore\"] = arg_max(TimeGenerated, error_msg)\n    by [\"Service Provider\"] = service_provider\n| sort by [\"Errori\"] desc",
-                "size": 0,
-                "title": "❌ Errori inattesi per Service Provider (dettaglio)",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "table"
-              },
-              "customWidth": "50",
-              "name": "❌ Errori inattesi per Service Provider (dettaglio)",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Rtp sent successfully with id:\"\n| extend\n    rtp_id     = extract(@\"Rtp sent successfully with id: (\\S+)\", 1, Message),\n    resource_id = tostring(Properties.resource_id),\n    payee_name  = tostring(Properties.payee_name)\n| project\n    [\"Data\"]           = TimeGenerated,\n    [\"RTP ID\"]         = rtp_id,\n    [\"Resource ID\"]    = resource_id,\n    [\"Ente Creditore\"] = payee_name\n| sort by [\"Data\"] desc\n| limit 250",
-                "size": 0,
-                "title": "✅ Ultimi invii con successo per Resource ID - Limit 250",
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "table"
-              },
-              "customWidth": "50",
-              "name": "✅ Ultimi invii con successo per Resource ID",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error sending Rtp to be sent:\"\n| extend\n    resource_id = tostring(Properties.resource_id),\n    errorMessage = replace_string(Message, \"Error sending Rtp to be sent:\", \"\")\n| where errorMessage !contains \"The payer is not activated\"\n| summarize\n    errorCount = count(),\n    lastError = arg_max(TimeGenerated, errorMessage)\n        by resource_id\n| project-rename\n    [\"RTP id\"] = resource_id,\n    [\"Errori\"] = errorCount,\n    [\"Ultimo errore\"] = lastError\n| sort by [\"Errori\"] desc\n| limit 250",
-                "size": 0,
-                "title": "❌ Invii falliti per RTP Resource ID (Errori Generici) - Limit 250",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ]
-              },
-              "customWidth": "50",
-              "name": "Invii falliti per RTP resource id (Errori Generici)",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error sending Rtp to be sent:\"\n| extend\n    resource_id = tostring(Properties.resource_id),\n    errorMessage = replace_string(Message, \"Error sending Rtp to be sent:\", \"\")\n| where errorMessage contains \"The payer is not activated\"\n| summarize\n    errorCount = count(),\n    lastError = arg_max(TimeGenerated, errorMessage)\n        by resource_id\n| project-rename\n    [\"RTP id\"] = resource_id,\n    [\"Errori\"] = errorCount,\n    [\"Ultimo errore\"] = lastError\n| sort by [\"Errori\"] desc\n| limit 250",
-                "size": 0,
-                "title": "❌ Invii falliti per RTP Resource ID (Payer Non Attivato) - Limit 250",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ]
-              },
-              "customWidth": "50",
-              "name": "Invii falliti per RTP resource id (Payer Non Attivato)",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Retries exhausted after attempts\"\n| extend ServiceProvider = tostring(Properties.debtor_service_provider)\n| extend ServiceProvider = iff(isempty(ServiceProvider), \"N/A\", ServiceProvider)\n| summarize retries = count() by ServiceProvider\n| order by retries desc\n",
-                "size": 0,
-                "title": "Retry per invii SRTP",
-                "noDataMessageStyle": 3,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "table"
-              },
-              "customWidth": "50",
-              "name": "Retry per invii SRTP",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message contains \"Message discarded due to out of order timestamp\"\n| parse Message with * \"messageTimestamp: \" messageTimestamp \n                       \", lastProcessedTimestamp: \" lastProcessedTimestamp \n                       \", status: \" status\n                       \", operation: \" operation\n                       \", id: \" id\n| extend \n    message_time = unixtime_milliseconds_todatetime(tolong(messageTimestamp)),\n    last_processed_time = unixtime_milliseconds_todatetime(tolong(lastProcessedTimestamp)),\n    time_difference = tolong(lastProcessedTimestamp) - tolong(messageTimestamp)\n| project \n    ['Log Time'] = TimeGenerated,\n    ['Message Time'] = message_time, \n    ['Last Processed Time'] = last_processed_time, \n    ['Time Difference Milliseconds'] = time_difference,\n    ['Time Difference Days'] = time_difference / (1000 * 60 * 60 * 24),\n    ['Message Timestamp'] = messageTimestamp, \n    ['Last Processed Timestamp'] = lastProcessedTimestamp,\n    ['Status'] = status, \n    ['Operation'] = operation, \n    ['Message Id'] = id\n| order by ['Log Time'] desc\n",
-                "size": 0,
-                "title": "❌ Messaggi scartati per Out-of-order Timestamp",
-                "noDataMessageStyle": 3,
-                "timeContext": {
-                  "durationMs": 2592000000
-                },
-                "showExportToExcel": true,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "gridSettings": {
-                  "rowLimit": 10000
-                }
-              },
-              "name": "❌ Messaggi scartati per Out-of-order Timestamp"
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where TimeGenerated {evaluation_window:query}\n| where AppRoleName == \"rtp-sender\"\n| summarize\n    Successo   = countif(Message startswith \"Rtp sent successfully with id:\"),\n    Errori     = countif(\n                    Message startswith \"Error finding activation data with resourceId:\" \n                    or Message startswith \"Error saving Rtp to be sent:\" \n                    or Message startswith \"Error sending Rtp to be sent:\"\n                 )\n  by bin(TimeGenerated, 1h)\n| project TimeGenerated, Successo, Errori\n| render timechart\n",
-                "size": 0,
-                "title": "Invii RTP nel tempo (Successi vs Fallimenti) in bin 1 ora",
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "chartSettings": {
-                  "xSettings": {
-                    "numberFormatSettings": {
-                      "unit": 0,
-                      "options": {
-                        "style": "decimal",
-                        "useGrouping": true
-                      }
-                    }
-                  }
-                }
-              },
-              "name": "query - 12"
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where TimeGenerated {evaluation_window:query}\n| where AppRoleName == 'rtp-sender'\n| where Message startswith \"Rtp sent successfully with id:\"\n| summarize \n    [\"Invii con successo\"] = count() \n  by \n    [\"Debtor Service Provider\"] = tostring(Properties.service_provider)\n| sort by [\"Invii con successo\"] desc\n",
+                "query": " let saveLog = AppTraces\n | where TimeGenerated {evaluation_window:query}\n | where AppRoleName == \"rtp-sender\"\n | where Message startswith \"Rtp to be sent saved with id:\"\n | extend DebtorSP = extract(@\"service_provider:\\s*(\\S+)\", 1, Message)\n | project OperationId, DebtorSP;\n AppTraces\n | where TimeGenerated {evaluation_window:query}\n | where AppRoleName == \"rtp-sender\"\n | where Message startswith \"Rtp sent successfully with id:\"\n | join kind=inner saveLog on OperationId\n | summarize [\"Invii con successo\"] = count() by [\"Debtor Service Provider\"] = DebtorSP\n | sort by [\"Invii con successo\"] desc",
                 "size": 0,
                 "title": "✅ Invii con successo per Service Provider del debitore",
                 "queryType": 0,
@@ -1287,6 +743,480 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
+                "query": " let ops = AppTraces\n | where TimeGenerated {evaluation_window:query}\n | where AppRoleName == \"rtp-sender\"\n | where Message startswith \"Operation: \"\n | extend Operation = extract(@\"Operation: (\\w+)\", 1, Message)\n | summarize Operation = any(Operation) by OperationId;\n let successes = AppTraces\n | where TimeGenerated {evaluation_window:query}\n | where AppRoleName == \"rtp-sender\"\n | where Message == \"Successfully processed message.\"\n | summarize TimeGenerated = min(TimeGenerated) by OperationId;\n let errors = AppTraces\n | where TimeGenerated {evaluation_window:query}\n | where AppRoleName == \"rtp-sender\"\n | where Message startswith \"Error processing message.\"\n | where Message !contains \"PayerNotActivatedException\"\n | where Message !contains \"InvalidTransitionException\"\n | where Message !contains \"RtpNotFoundException\"\n | summarize TimeGenerated = min(TimeGenerated) by OperationId;\n union\n     (successes | join kind=inner ops on OperationId | extend Series = strcat(\"✅ \", Operation)),\n     (errors    | join kind=inner ops on OperationId | extend Series = strcat(\"❌ \", Operation))\n | summarize Count = count() by bin(TimeGenerated, 1h), Series\n | render timechart",
+                "size": 0,
+                "title": "Invii RTP nel tempo (Successi vs Fallimenti) in bin 1 ora",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "visualization": "timechart",
+                "chartSettings": {
+                  "xSettings": {
+                    "numberFormatSettings": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": true
+                      }
+                    }
+                  }
+                }
+              },
+              "name": "Invii RTP nel tempo (Successi vs Fallimenti) in bin 1 ora"
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "let fallimenti = AppTraces\n | where AppRoleName == 'rtp-sender'\n | where TimeGenerated {evaluation_window:query}\n | where SeverityLevel == 3\n | where Message startswith \"Error sending Rtp to be sent:\"\n | extend _err = trim(\" \", replace_string(Message, \"Error sending Rtp to be sent:\", \"\"))\n | extend Categoria = case(\n     _err contains \"payer is not activated\",                \"⚠️ Payer non attivato\",\n     _err contains \"rejected\" or _err contains \"Reject\",   \"❌ Rejection SEPA\",\n     _err contains \"imeout\",                               \"❌ Timeout\",\n     _err contains \"Connection\" or _err contains \"refused\", \"❌ Errore di rete\",\n     _err contains \"MongoWrite\" or _err contains \"Mongo\"\n         or _err contains \"TooManyRequest\",                \"❌ Errore DB Mongo\",\n     _err contains \"PayeeNotFound\"\n         or _err contains \"ServiceProviderNotFound\",       \"❌ Payee/SP non trovato\",\n     _err contains \"InvalidTransition\"\n         or _err contains \"InvalidStatus\",                 \"❌ Transizione invalida\",\n     \"❌ Altro / non classificato\"\n )\n | summarize Conteggio = count() by Categoria\n | extend Tipo = \"Fallimento\";\n \n let successi = AppTraces\n | where AppRoleName == 'rtp-sender'\n | where TimeGenerated {evaluation_window:query}\n | where SeverityLevel == 1\n | where Message startswith \"Rtp sent successfully with id:\"\n | summarize Conteggio = count()\n | extend Categoria = \"✅ Successo\", Tipo = \"Successo\";\n \n let dettaglio = union fallimenti, successi;\n \n let totali = dettaglio\n | summarize Conteggio = sum(Conteggio) by Tipo\n | extend Categoria = strcat(\"📊 Totale \", Tipo);\n \n union dettaglio, totali\n | project Categoria, Tipo, Conteggio\n | sort by Tipo asc, Conteggio desc",
+                "size": 0,
+                "title": "Monitoraggio di invii falliti o non processati per tipologia",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "visualization": "piechart",
+                "chartSettings": {
+                  "ySettings": {
+                    "numberFormatSettings": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": true
+                      }
+                    }
+                  }
+                }
+              },
+              "name": "Monitoraggio globale degli Invii RTP",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Rtp sent successfully with id:\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
+                "size": 0,
+                "title": "✅ Invii totali con successo (APIM + CODA)",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "visualization": "stat",
+                "statSettings": {
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "numberFormatSettings": {
+                    "unit": 0,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
+              },
+              "customWidth": "25",
+              "name": "✅ Invii totali con successo (APIM + CODA)",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": " AppTraces\n | where AppRoleName == 'rtp-sender'\n | where TimeGenerated {evaluation_window:query}\n | where SeverityLevel == 3\n | where Message startswith \"Send RTP request rejected for\"\n | extend service_provider = extract(@\"Send RTP request rejected for ([^:]+):\", 1, Message)\n | extend rtp_operation_id = extract(@\"RTP Id:\\s*(\\d+)\", 1, Message)\n | project\n     TimeGenerated,\n     service_provider,\n     rtp_operation_id,\n     correlation_id = Properties[\"correlation_id\"],\n     resource_id    = Properties[\"resource_id\"]\n | top 100 by TimeGenerated desc",
+                "size": 0,
+                "title": "✅ Invii totali con successo (APIM + CODA)",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "visualization": "table",
+                "statSettings": {
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "numberFormatSettings": {
+                    "unit": 0,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
+              },
+              "customWidth": "75",
+              "name": "✅ Invii totali con successo (APIM + CODA)",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error sending Rtp to be sent:\" or Message startswith \"Send RTP request rejected for \" or Message startswith \"Error while handling RTP send for \"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
+                "size": 0,
+                "title": "❌ Errore nell'invio del RTP",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "visualization": "stat",
+                "statSettings": {
+                  "valueField": "totalRequestsString",
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
+              },
+              "customWidth": "25",
+              "name": "❌ Invii falliti (Servizio) - Copy - Copy",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": " AppTraces\n | where AppRoleName == 'rtp-sender'\n | where TimeGenerated {evaluation_window:query}\n | where SeverityLevel == 3\n | where Message startswith \"Error sending Rtp to be sent:\"\n | where Message !contains \"payer is not activated\"\n | extend errorMessage = trim(\" \", replace_string(Message, \"Error sending Rtp to be sent:\", \"\"))\n | extend Categoria = case(\n     errorMessage contains \"TooMany\" or errorMessage contains \"429\",          \"Troppe richieste MongoDB\",\n     errorMessage contains \"DuplicateKey\" or errorMessage contains \"dup key\", \"Chiave duplicata MongoDB\",\n     errorMessage contains \"MongoWrite\" or errorMessage contains \"Mongo\",     \"Errore MongoDB\",\n     errorMessage contains \"imeout\",                                          \"Timeout\",\n     errorMessage contains \"Connection\" or errorMessage contains \"refused\",   \"Errore di rete\",\n     errorMessage contains \"rejected\" or errorMessage contains \"Reject\",      \"Rejection SEPA\",\n     \"Altro\"\n )\n | project\n     TimeGenerated,\n     Categoria,\n     errorMessage,\n     creditor_service_provider = Properties[\"creditor_service_provider\"],\n     correlation_id            = Properties[\"correlation_id\"],\n     resource_id               = Properties[\"resource_id\"]\n | top 250 by TimeGenerated desc",
+                "size": 0,
+                "title": "❌ Catch-all errori invio",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "statSettings": {
+                  "valueField": "totalRequestsString",
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
+              },
+              "customWidth": "75",
+              "name": "❌ Catch-all errori invio",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": " AppTraces\n | where AppRoleName == 'rtp-sender'\n | where TimeGenerated {evaluation_window:query}\n | where SeverityLevel == 3\n | where Message startswith \"Send RTP request rejected for\"\n | extend service_provider = extract(@\"Send RTP request rejected for ([^:]+):\", 1, Message)\n | extend rtp_operation_id = extract(@\"RTP Id:\\s*(\\d+)\", 1, Message)\n | extend errorMessage     = trim(\" \", extract(@\"Send RTP request rejected for [^:]+:\\s*(.+)$\", 1, Message))\n | project\n     TimeGenerated,\n     service_provider,\n     rtp_operation_id,\n     errorMessage,\n     correlation_id = Properties[\"correlation_id\"],\n     resource_id    = Properties[\"resource_id\"]\n | top 250 by TimeGenerated desc",
+                "size": 0,
+                "title": "❌ REJECTION esplicita EPC",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "statSettings": {
+                  "valueField": "totalRequestsString",
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
+              },
+              "name": "❌ REJECTION esplicita EPC",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "\n AppTraces\n | where AppRoleName == 'rtp-sender'\n | where TimeGenerated {evaluation_window:query}\n | where SeverityLevel == 3\n | where Message startswith \"Error while handling RTP send for\"\n | extend resource_id_msg = extract(@\"Error while handling RTP send for ([^\\s]+)\", 1, Message)\n | extend errorMessage    = trim(\" \", extract(@\"Error while handling RTP send for [^\\s]+\\s(.+)$\", 1, Message))\n | project\n     TimeGenerated,\n     errorMessage,\n     resource_id               = coalesce(tostring(Properties[\"resource_id\"]), resource_id_msg),\n     creditor_service_provider = Properties[\"creditor_service_provider\"],\n     correlation_id            = Properties[\"correlation_id\"]\n | top 50 by TimeGenerated desc",
+                "size": 0,
+                "title": "❌ Errore Handler post retry",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "statSettings": {
+                  "valueField": "totalRequestsString",
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
+              },
+              "name": "❌ Errore Handler post retry",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where SeverityLevel == 3\n| where Message startswith \"Error saving Rtp to be sent:\"\n| where Message !contains \"payer is not activated\"\n| extend error_detail = trim(@\"\\.\", extract(@\"Error saving Rtp to be sent:\\s*(.+)$\", 1, Message))\n| extend Categoria = case(\n    error_detail contains \"TooMany\" or error_detail contains \"429\",          \"Troppe richieste MongoDB\",\n    error_detail contains \"DuplicateKey\" or error_detail contains \"dup key\", \"Chiave duplicata\",\n    error_detail contains \"MongoWrite\" or error_detail contains \"Write\",     \"Errore scrittura MongoDB\",\n    error_detail contains \"imeout\",                                          \"Timeout\",\n    error_detail contains \"Connection\" or error_detail contains \"refused\",   \"Errore connessione MongoDB\",\n    \"Altro\"\n)\n| project\n    TimeGenerated,\n    Categoria,\n    error_detail,\n    message_id     = Properties[\"message_id\"],\n    correlation_id = Properties[\"correlation_id\"],\n    resource_id    = Properties[\"resource_id\"]\n| top 50 by TimeGenerated desc",
+                "size": 0,
+                "title": "❌ Errore nel salvataggio a DB del RTP",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "statSettings": {
+                  "valueField": "totalRequestsString",
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
+              },
+              "name": "❌ Errore nel salvataggio a DB del RTP",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": " AppTraces\n | where AppRoleName == 'rtp-sender'\n | where TimeGenerated {evaluation_window:query}\n | where Message startswith \"Send RTP request rejected for\"\n | extend service_provider  = extract(@\"Send RTP request rejected for ([^:]+):\", 1, Message)\n | extend rtp_operation_id  = extract(@\"RTP Id:\\s*(\\d+)\", 1, Message)\n | project\n     TimeGenerated,\n     service_provider,\n     rtp_operation_id,\n     message_id     = Properties[\"message_id\"],\n     correlation_id = Properties[\"correlation_id\"],\n     resource_id    = Properties[\"resource_id\"]\n | top 50 by TimeGenerated desc",
+                "size": 0,
+                "title": "❌ RTP rifiutati dal Service Provider",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "statSettings": {
+                  "valueField": "totalRequestsString",
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
+              },
+              "name": "❌ RTP rifiutati dal Service Provider",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where SeverityLevel == 3\n| where Message startswith \"An unexpected error occurred while sending RTP\"\n| extend\n    service_provider = tostring(Properties[\"debtor_service_provider\"]),\n    error_msg        = extract(@\"Error:\\s*(.+)$\", 1, Message)\n| summarize\n    Errori             = count(),\n    [\"Ultimo errore\"]  = arg_max(TimeGenerated, error_msg)\n    by [\"Service Provider\"] = service_provider\n| sort by Errori desc",
+                "size": 0,
+                "title": "❌ Errori inattesi per Service Provider",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "visualization": "table"
+              },
+              "name": "❌ Errori inattesi per Service Provider",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where SeverityLevel == 3\n| where Message startswith \"An unexpected error occurred while sending RTP\"\n| extend service_provider = extract(@\"to ([^\\s.]+)\\.\", 1, Message)\n| extend error_detail     = extract(@\"Error:\\s*(.+)$\", 1, Message)\n| extend Categoria = case(\n    error_detail contains \"imeout\",                                    \"Timeout\",\n    error_detail contains \"Connection\"\n        or error_detail contains \"refused\"\n        or error_detail contains \"Network\",                            \"Errore di rete\",\n    error_detail contains \"SSL\" or error_detail contains \"TLS\",        \"Errore SSL/TLS\",\n    error_detail contains \"reset\" or error_detail contains \"closed\",   \"Connessione chiusa\",\n    \"Altro\"\n)\n| project\n    TimeGenerated,\n    Categoria,\n    service_provider,\n    error_detail,\n    message_id     = Properties[\"message_id\"],\n    correlation_id = Properties[\"correlation_id\"],\n    resource_id    = Properties[\"resource_id\"]\n| top 50 by TimeGenerated desc",
+                "size": 0,
+                "title": "❌ Errori inattesi nell'invio",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "statSettings": {
+                  "valueField": "totalRequestsString",
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
+              },
+              "name": "❌ Errori inattesi nell'invio",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where SeverityLevel == 3\n| where Message startswith \"WebClientResponseException while fetching payees\"\n    or Message startswith \"An unexpected error occurred while fetching payees\"\n| extend Categoria = case(\n    Message startswith \"WebClientResponseException while fetching payees\",\n        strcat(\"HTTP \", extract(@\"Status Code\\s*:\\s*(\\S+)\", 1, Message)),\n    extract(@\"Error:\\s*(.+)\", 1, Message)\n)\n| project\n    TimeGenerated,\n    Categoria,\n    message_id     = Properties[\"message_id\"],\n    correlation_id = Properties[\"correlation_id\"],\n    resource_id    = Properties[\"resource_id\"]\n| top 50 by TimeGenerated desc",
+                "size": 0,
+                "title": "❌ Errori nel recupero della lista enti dal microservizio",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "statSettings": {
+                  "valueField": "totalRequestsString",
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
+              },
+              "name": "❌ Errori nel recupero della lista enti dal microservizio",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "AppExceptions\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| summarize\n    [\"Occorrenze\"] = count(),\n    [\"Ultimo messaggio\"] = arg_max(TimeGenerated, OuterMessage)\n    by [\"Tipo eccezione\"] = ExceptionType\n| sort by [\"Occorrenze\"] desc",
+                "size": 0,
+                "title": "Eccezioni Java rtp-sender (AppExceptions)",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "visualization": "table"
+              },
+              "customWidth": "100",
+              "name": "Eccezioni Java rtp-sender (AppExceptions)",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "AppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Retries exhausted after attempts\"\n| extend ServiceProvider = tostring(Properties.debtor_service_provider)\n| extend ServiceProvider = iff(isempty(ServiceProvider), \"N/A\", ServiceProvider)\n| summarize retries = count() by ServiceProvider\n| order by retries desc\n",
+                "size": 0,
+                "title": "Retry per invii SRTP",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "visualization": "table"
+              },
+              "name": "Retry per invii SRTP",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
                 "query": "let Sent =\nAppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Rtp sent successfully with id:\"\n| summarize sentCount = count()\n| extend key = 1;\n\nlet PaidThroughOtherChannel =\nAppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message has \"Successfully updated paid RTP with different psp scenario\"\n| extend pspBic = coalesce(extract(@\"PSP BIC:\\s*([^,\\s}]+)\", 1, Message), \"unknown\")\n| summarize paidOtherCount = count(), distinctPsp = dcountif(pspBic, pspBic != \"unknown\")\n| extend key = 1;\n\nSent\n| join kind=fullouter PaidThroughOtherChannel on key\n| extend sentCount = coalesce(sentCount, 0),\n         paidOtherCount = coalesce(paidOtherCount, 0),\n         distinctPsp = coalesce(distinctPsp, 0)\n| extend paidOtherPercentage = iff(sentCount > 0, 100.0 * todouble(paidOtherCount) / todouble(sentCount), 0.0)\n| project [\"RTP inviati\"] = sentCount,\n          [\"RTP pagati attraverso altro canale\"] = paidOtherCount,\n          [\"PSP distinti\"] = distinctPsp,\n          [\"% pagati attraverso altro canale\"] = paidOtherPercentage\n",
                 "size": 0,
                 "title": "RTP pagati tramite altro canale",
@@ -1294,6 +1224,20 @@
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "gridSettings": {
+                  "sortBy": [
+                    {
+                      "itemKey": "RTP pagati attraverso altro canale",
+                      "sortOrder": 1
+                    }
+                  ]
+                },
+                "sortBy": [
+                  {
+                    "itemKey": "RTP pagati attraverso altro canale",
+                    "sortOrder": 1
+                  }
                 ]
               },
               "name": "query - 19",
@@ -1385,43 +1329,24 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Rtp sent successfully with id:\"\n| extend\n    rtp_id     = extract(@\"Rtp sent successfully with id: (\\S+)\", 1, Message),\n    resource_id = tostring(Properties.resource_id),\n    payee_name  = tostring(Properties.payee_name)\n| project\n    [\"Data\"]           = TimeGenerated,\n    [\"RTP ID\"]         = rtp_id,\n    [\"Resource ID\"]    = resource_id,\n    [\"Ente Creditore\"] = payee_name\n| sort by [\"Data\"] desc\n| limit 50",
+                "query": "AppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message contains \"Message discarded due to out of order timestamp\"\n| parse Message with * \"messageTimestamp: \" messageTimestamp \n                       \", lastProcessedTimestamp: \" lastProcessedTimestamp \n                       \", status: \" status\n                       \", operation: \" operation\n                       \", id: \" id\n| extend \n    message_time = unixtime_milliseconds_todatetime(tolong(messageTimestamp)),\n    last_processed_time = unixtime_milliseconds_todatetime(tolong(lastProcessedTimestamp)),\n    time_difference = tolong(lastProcessedTimestamp) - tolong(messageTimestamp)\n| project \n    ['Log Time'] = TimeGenerated,\n    ['Message Time'] = message_time, \n    ['Last Processed Time'] = last_processed_time, \n    ['Time Difference Milliseconds'] = time_difference,\n    ['Time Difference Days'] = time_difference / (1000 * 60 * 60 * 24),\n    ['Message Timestamp'] = messageTimestamp, \n    ['Last Processed Timestamp'] = lastProcessedTimestamp,\n    ['Status'] = status, \n    ['Operation'] = operation, \n    ['Message Id'] = id\n| order by ['Log Time'] desc\n",
                 "size": 0,
-                "title": "✅ Ultimi 50 invii con successo",
-                "noDataMessageStyle": 5,
-                "queryType": 0,
-                "resourceType": "microsoft.operationalinsights/workspaces",
-                "crossComponentResources": [
-                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "table"
-              },
-              "customWidth": "50",
-              "name": "✅ Ultimi 50 invii con successo",
-              "styleSettings": {
-                "showBorder": true
-              }
-            },
-            {
-              "type": 3,
-              "content": {
-                "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error sending Rtp to be sent:\"\n    or Message startswith \"Error finding activation data with resourceId:\"\n    or Message startswith \"Error saving Rtp to be sent:\"\n| extend\n    resource_id = tostring(Properties.resource_id),\n    payee_name  = tostring(Properties.payee_name),\n    raw_msg     = trim(\" \", Message)\n| extend Categoria = case(\n    raw_msg contains \"payer is not activated\",             \"Payer non attivato\",\n    raw_msg contains \"rejected\" or raw_msg contains \"Reject\", \"Rejection SEPA\",\n    raw_msg contains \"imout\" or raw_msg contains \"Timeout\",   \"Timeout\",\n    raw_msg contains \"Connection\" or raw_msg contains \"refused\", \"Errore di rete\",\n    raw_msg contains \"MongoWrite\" or raw_msg contains \"Mongo\",   \"Errore DB Mongo\",\n    raw_msg contains \"activation data\",                   \"Attivazione non trovata\",\n    \"Altro\"\n)\n| project\n    [\"Data\"]            = TimeGenerated,\n    [\"Resource ID\"]     = resource_id,\n    [\"Ente Creditore\"]  = payee_name,\n    [\"Categoria\"]       = Categoria,\n    [\"Messaggio errore\"] = raw_msg\n| sort by [\"Data\"] desc\n| limit 50",
-                "size": 0,
-                "title": "❌ Ultimi 50 fallimenti invio",
+                "title": "❌ Messaggi scartati per Out-of-order Timestamp",
                 "noDataMessageStyle": 3,
+                "timeContext": {
+                  "durationMs": 2592000000
+                },
+                "showExportToExcel": true,
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
                 ],
-                "visualization": "table"
+                "gridSettings": {
+                  "rowLimit": 10000
+                }
               },
-              "customWidth": "50",
-              "name": "❌ Ultimi 50 fallimenti invio",
-              "styleSettings": {
-                "showBorder": true
-              }
+              "name": "❌ Messaggi scartati per Out-of-order Timestamp"
             }
           ]
         },
@@ -1442,9 +1367,95 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Successfully cancelled RTP to service provider debtor\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
+                "query": "AppTraces\n| where TimeGenerated {evaluation_window:query}\n| where AppRoleName == \"rtp-sender\"\n| where Message startswith \"RTP cancellation succeeded\"\n| extend DebtorSP = extract(@\"service_provider:\\s*(\\S+)\", 1, Message)\n| where isnotempty(DebtorSP)\n| summarize [\"Cancellazioni con successo\"] = count() by [\"Debtor Service Provider\"] = DebtorSP\n| sort by [\"Cancellazioni con successo\"] desc",
                 "size": 0,
-                "title": "✅ Cancellazioni totali con successo (CODA + API)",
+                "title": "✅ Cancellazioni con successo per Service Provider del debitore",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "visualization": "barchart",
+                "sortBy": [],
+                "chartSettings": {
+                  "ySettings": {
+                    "numberFormatSettings": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": true
+                      }
+                    }
+                  }
+                }
+              },
+              "name": "✅ Cancellazioni con successo per Service Provider del debitore"
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "let successes = AppTraces\n| where TimeGenerated {evaluation_window:query}\n| where AppRoleName == \"rtp-sender\"\n| where Message startswith \"RTP cancellation succeeded\"\n| extend DebtorSP = extract(@\"service_provider:\\s*(\\S+)\", 1, Message)\n| summarize TimeGenerated = min(TimeGenerated) by OperationId, DebtorSP;\nlet errors = AppTraces\n| where TimeGenerated {evaluation_window:query}\n| where AppRoleName == \"rtp-sender\"\n| where Message startswith \"Error cancel RTP:\"\n| extend DebtorSP = extract(@\"service_provider:\\s*(\\S+)\", 1, Message)\n| summarize TimeGenerated = min(TimeGenerated) by OperationId, DebtorSP;\nunion\n    (successes | extend Series = strcat(\"✅ \", DebtorSP)),\n    (errors    | extend Series = strcat(\"❌ \", DebtorSP))\n| summarize Count = count() by bin(TimeGenerated, 1h), Series\n| render timechart",
+                "size": 0,
+                "title": "Cancellazioni nel tempo (Successi vs Fallimenti) in bin 1 ora",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "visualization": "timechart",
+                "chartSettings": {
+                  "xSettings": {
+                    "numberFormatSettings": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": true
+                      }
+                    }
+                  }
+                }
+              },
+              "name": "Cancellazioni nel tempo (Successi vs Fallimenti) in bin 1 ora"
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "let fallimenti = AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error cancel RTP:\"\n| extend _err = trim(\" \", extract(@\"Error cancel RTP:\\s*(.+?)\\. service_provider:\", 1, Message))\n| extend Categoria = case(\n    _err contains \"rejected\" or _err contains \"Reject\",    \"❌ Rejection SEPA\",\n    _err contains \"imeout\",                                \"❌ Timeout\",\n    _err contains \"Connection\" or _err contains \"refused\", \"❌ Errore di rete\",\n    _err contains \"Mongo\" or _err contains \"TooManyRequest\", \"❌ Errore DB Mongo\",\n    _err contains \"NotFound\" or _err contains \"not found\",  \"❌ RTP non trovato\",\n    _err contains \"InvalidTransition\" or _err contains \"InvalidStatus\", \"❌ Transizione invalida\",\n    \"❌ Altro / non classificato\"\n)\n| summarize Conteggio = count() by Categoria\n| extend Tipo = \"Fallimento\";\nlet successi = AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"RTP cancellation succeeded\"\n| summarize Conteggio = count()\n| extend Categoria = \"✅ Successo\", Tipo = \"Successo\";\nlet dettaglio = union fallimenti, successi;\nlet totali = dettaglio\n| summarize Conteggio = sum(Conteggio) by Tipo\n| extend Categoria = strcat(\"📊 Totale \", Tipo);\nunion dettaglio, totali\n| project Categoria, Tipo, Conteggio\n| sort by Tipo asc, Conteggio desc",
+                "size": 0,
+                "title": "Monitoraggio globale delle Cancellazioni per tipologia",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "visualization": "piechart",
+                "chartSettings": {
+                  "ySettings": {
+                    "numberFormatSettings": {
+                      "unit": 0,
+                      "options": {
+                        "style": "decimal",
+                        "useGrouping": true
+                      }
+                    }
+                  }
+                }
+              },
+              "name": "Monitoraggio globale delle Cancellazioni per tipologia",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"RTP cancellation succeeded\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
+                "size": 0,
+                "title": "✅ Cancellazioni totali con successo",
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
@@ -1452,7 +1463,6 @@
                 ],
                 "visualization": "stat",
                 "statSettings": {
-                  "valueField": "totalRequestsString",
                   "valueAggregation": "None",
                   "colorSettings": {
                     "type": "static",
@@ -1462,6 +1472,12 @@
                   },
                   "iconSettings": {
                     "thresholdsGrid": []
+                  },
+                  "numberFormatSettings": {
+                    "unit": 0,
+                    "options": {
+                      "style": "decimal"
+                    }
                   },
                   "tagText": "",
                   "valueFontStyle": "auto"
@@ -1477,9 +1493,9 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error cancel RTP:\" or Message startswith \"Error retrieving RTP:\"\n// \"Error retrieving RTP:\" -> API log\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error cancel RTP:\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
                 "size": 0,
-                "title": "❌ Cancellazioni totali falliti (CODA + API)",
+                "title": "❌ Cancellazioni totali fallite",
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
@@ -1487,7 +1503,6 @@
                 ],
                 "visualization": "stat",
                 "statSettings": {
-                  "valueField": "totalRequestsString",
                   "valueAggregation": "None",
                   "colorSettings": {
                     "type": "static",
@@ -1498,12 +1513,18 @@
                   "iconSettings": {
                     "thresholdsGrid": []
                   },
+                  "numberFormatSettings": {
+                    "unit": 0,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  },
                   "tagText": "",
                   "valueFontStyle": "auto"
                 }
               },
               "customWidth": "25",
-              "name": "❌ Cancellazioni totali falliti",
+              "name": "❌ Cancellazioni totali fallite",
               "styleSettings": {
                 "showBorder": true
               }
@@ -1512,9 +1533,49 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith_cs \"DELETE_GDP_RTP_NOT_FOUND\"\n| extend\n    OperationId    = extract(@\"operationId=(\\d+)\", 1, Message),\n    EventDispatcher = extract(@\"eventDispatcher=([^,]+)\", 1, Message),\n    GdpMessageId   = extract(@\"gdpMessageId=(\\d+)\", 1, Message)\n| project\n    ['Time Generated']  = TimeGenerated,\n    ['Operation Id']    = OperationId,\n    ['Event Dispatcher'] = EventDispatcher,\n    ['GDP Message Id']  = GdpMessageId,\n    ['Message']         = Message\n| order by ['Time Generated'] desc\n",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Retries exhausted after attempts:\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
                 "size": 0,
-                "title": "❌ Delete fallite su RTP non presenti a DB",
+                "title": "❌ Retry esauriti (cancellazioni SRTP)",
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ],
+                "visualization": "stat",
+                "statSettings": {
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "numberFormatSettings": {
+                    "unit": 0,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
+              },
+              "customWidth": "25",
+              "name": "❌ Retry esauriti (cancellazioni SRTP)",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where SeverityLevel == 3\n| where Message startswith \"Handling SendRequestRejectedException during RTP cancellation\"\n| project\n    TimeGenerated,\n    resource_id               = Properties[\"resource_id\"],\n    debtor_service_provider   = Properties[\"debtor_service_provider\"],\n    creditor_service_provider = Properties[\"creditor_service_provider\"],\n    payee_name                = Properties[\"payee_name\"],\n    correlation_id            = Properties[\"correlation_id\"],\n    Message\n| top 100 by TimeGenerated desc",
+                "size": 0,
+                "title": "❌ REJECTION EPC anomala durante cancellazione (RJCT imprevisto)",
                 "noDataMessageStyle": 3,
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
@@ -1522,8 +1583,7 @@
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
                 ]
               },
-              "customWidth": "50",
-              "name": "query - 18",
+              "name": "❌ REJECTION EPC anomala durante cancellazione (RJCT imprevisto)",
               "styleSettings": {
                 "showBorder": true
               }
@@ -1532,89 +1592,66 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where TimeGenerated {evaluation_window:query}\n| where AppRoleName == \"rtp-sender\"\n| summarize\n    Successo   = countif(Message hasprefix \"Successfully cancelled RTP to service provider debtor\"),\n    Fallimento = countif(Message hasprefix \"Error cancel RTP:\")\n  by bin(TimeGenerated, 1h)\n| project TimeGenerated, Successo, Fallimento\n| render timechart",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where SeverityLevel == 3\n| where Message startswith \"Error cancel RTP:\"\n| extend errorMessage = trim(\" \", extract(@\"Error cancel RTP:\\s*(.+?)\\. service_provider:\", 1, Message))\n| extend service_provider = extract(@\"service_provider:\\s*(\\S+)\", 1, Message)\n| extend Categoria = case(\n    errorMessage contains \"TooMany\" or errorMessage contains \"429\",          \"Troppe richieste MongoDB\",\n    errorMessage contains \"DuplicateKey\" or errorMessage contains \"dup key\", \"Chiave duplicata MongoDB\",\n    errorMessage contains \"MongoWrite\" or errorMessage contains \"Mongo\",     \"Errore MongoDB\",\n    errorMessage contains \"imeout\",                                          \"Timeout\",\n    errorMessage contains \"Connection\" or errorMessage contains \"refused\",   \"Errore di rete\",\n    errorMessage contains \"rejected\" or errorMessage contains \"Reject\",      \"Rejection SEPA\",\n    \"Altro\"\n)\n| project\n    TimeGenerated,\n    Categoria,\n    service_provider,\n    errorMessage,\n    correlation_id = Properties[\"correlation_id\"],\n    resource_id    = Properties[\"resource_id\"]\n| top 250 by TimeGenerated desc",
                 "size": 0,
-                "title": "Cancellazioni nel tempo (Successi vs Fallimenti)",
+                "title": "❌ Catch-all errori cancellazione per tipologia",
+                "noDataMessageStyle": 3,
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "chartSettings": {
-                  "ySettings": {
-                    "numberFormatSettings": {
-                      "unit": 0,
-                      "options": {
-                        "style": "decimal",
-                        "useGrouping": true
-                      }
-                    }
-                  }
-                }
+                ]
               },
-              "name": "Cancellazioni nel tempo (Successi vs Fallimenti)"
+              "name": "❌ Catch-all errori cancellazione per tipologia",
+              "styleSettings": {
+                "showBorder": true
+              }
             },
             {
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where TimeGenerated {evaluation_window:query}\n| where AppRoleName == 'rtp-sender'\n| where Message startswith \"RTP cancellation succeeded\" \n| summarize\n    [\"Cancellazioni con successo\"] = count()\n   by\n    [\"Debtor Service Provider\"] = tostring(Properties.service_provider)\n| sort by [\"Cancellazioni con successo\"] desc\n",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where SeverityLevel == 3\n| where Message startswith \"An unexpected error occurred while cancelling RTP\"\n| extend\n    service_provider = tostring(Properties[\"debtor_service_provider\"]),\n    error_msg        = extract(@\"Error:\\s*(.+)$\", 1, Message)\n| summarize\n    Errori = count(),\n    arg_max(TimeGenerated, error_msg)\n    by [\"Service Provider\"] = service_provider\n| project [\"Service Provider\"], Errori, [\"Ultimo errore\"] = error_msg\n| sort by Errori desc",
                 "size": 0,
-                "title": "✅ Cancellazioni con successo per Service Provider",
+                "title": "❌ Errori inattesi per Service Provider (cancellazioni)",
+                "noDataMessageStyle": 3,
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "unstackedbar",
-                "chartSettings": {
-                  "ySettings": {
-                    "numberFormatSettings": {
-                      "unit": 0,
-                      "options": {
-                        "style": "decimal",
-                        "useGrouping": true
-                      }
-                    }
-                  }
-                }
+                ]
               },
-              "name": "✅ Cancellazioni con successo per Service Provider"
+              "name": "❌ Errori inattesi per Service Provider (cancellazioni)",
+              "styleSettings": {
+                "showBorder": true
+              }
             },
             {
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where TimeGenerated {evaluation_window:query}\n| where AppRoleName == 'rtp-sender'\n| where Message startswith \"Error cancel RTP\" \n| summarize\n    [\"Cancellazioni con fallimento\"] = count()\n   by\n    [\"Debtor Service Provider\"] = tostring(Properties.service_provider)\n| sort by [\"Cancellazioni con fallimento\"] desc",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where SeverityLevel == 3\n| where Message startswith \"An unexpected error occurred while cancelling RTP\"\n| extend error_detail = extract(@\"Error:\\s*(.+)$\", 1, Message)\n| extend Categoria = case(\n    error_detail contains \"imeout\",                                     \"Timeout\",\n    error_detail contains \"Connection\"\n        or error_detail contains \"refused\"\n        or error_detail contains \"Network\",                             \"Errore di rete\",\n    error_detail contains \"SSL\" or error_detail contains \"TLS\",         \"Errore SSL/TLS\",\n    error_detail contains \"reset\" or error_detail contains \"closed\",    \"Connessione chiusa\",\n    \"Altro\"\n)\n| project\n    TimeGenerated,\n    Categoria,\n    debtor_service_provider   = Properties[\"debtor_service_provider\"],\n    creditor_service_provider = Properties[\"creditor_service_provider\"],\n    error_detail,\n    correlation_id = Properties[\"correlation_id\"],\n    resource_id    = Properties[\"resource_id\"]\n| top 100 by TimeGenerated desc",
                 "size": 0,
-                "title": "❌ Cancellazioni fallite per Service Provider",
+                "title": "❌ Errori inattesi nella cancellazione — dettaglio",
+                "noDataMessageStyle": 3,
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "table",
-                "chartSettings": {
-                  "ySettings": {
-                    "numberFormatSettings": {
-                      "unit": 0,
-                      "options": {
-                        "style": "decimal",
-                        "useGrouping": true
-                      }
-                    }
-                  }
-                }
+                ]
               },
-              "name": "❌ Cancellazioni fallite per Service Provider"
+              "name": "❌ Errori inattesi nella cancellazione — dettaglio",
+              "styleSettings": {
+                "showBorder": true
+              }
             },
             {
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Successfully cancelled draft RTP with id:\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Successfully cancelled draft RTP\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
                 "size": 0,
-                "title": "✅ Cancellazioni draft con successo (GPD DELETE)",
+                "title": "✅ Cancellazioni draft con successo (GPD UPDATE_DRAFT)",
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
@@ -1622,7 +1659,6 @@
                 ],
                 "visualization": "stat",
                 "statSettings": {
-                  "valueField": "totalRequestsString",
                   "valueAggregation": "None",
                   "colorSettings": {
                     "type": "static",
@@ -1633,12 +1669,18 @@
                   "iconSettings": {
                     "thresholdsGrid": []
                   },
+                  "numberFormatSettings": {
+                    "unit": 0,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  },
                   "tagText": "",
                   "valueFontStyle": "auto"
                 }
               },
               "customWidth": "25",
-              "name": "✅ Cancellazioni draft con successo (GPD DELETE)",
+              "name": "✅ Cancellazioni draft con successo (GPD UPDATE_DRAFT)",
               "styleSettings": {
                 "showBorder": true
               }
@@ -1649,8 +1691,7 @@
                 "version": "KqlItem/1.0",
                 "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error cancelling draft RTP:\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
                 "size": 0,
-                "title": "❌ Errori cancellazioni draft (GPD DELETE)",
-                "noDataMessageStyle": 3,
+                "title": "❌ Errori cancellazioni draft (GPD UPDATE_DRAFT)",
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
@@ -1658,7 +1699,6 @@
                 ],
                 "visualization": "stat",
                 "statSettings": {
-                  "valueField": "totalRequestsString",
                   "valueAggregation": "None",
                   "colorSettings": {
                     "type": "static",
@@ -1669,12 +1709,18 @@
                   "iconSettings": {
                     "thresholdsGrid": []
                   },
+                  "numberFormatSettings": {
+                    "unit": 0,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  },
                   "tagText": "",
                   "valueFontStyle": "auto"
                 }
               },
               "customWidth": "25",
-              "name": "❌ Errori cancellazioni draft (GPD DELETE)",
+              "name": "❌ Errori cancellazioni draft (GPD UPDATE_DRAFT)",
               "styleSettings": {
                 "showBorder": true
               }
@@ -1683,10 +1729,29 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Handling SendRequestRejectedException during RTP cancellation\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where SeverityLevel == 3\n| where Message startswith \"Error cancelling draft RTP:\"\n| project\n    TimeGenerated,\n    debtor_service_provider   = Properties[\"debtor_service_provider\"],\n    creditor_service_provider = Properties[\"creditor_service_provider\"],\n    resource_id               = Properties[\"resource_id\"],\n    correlation_id            = Properties[\"correlation_id\"],\n    Message\n| top 100 by TimeGenerated desc",
                 "size": 0,
-                "title": "❌ Cancellazioni anomale (RJCT imprevisto)",
+                "title": "❌ Errori cancellazioni draft — dettaglio",
                 "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ]
+              },
+              "customWidth": "50",
+              "name": "❌ Errori cancellazioni draft — dettaglio",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Triggering CANCEL transition for RTP\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
+                "size": 0,
+                "title": "✅ Callback CNCL — CANCEL confermati",
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
@@ -1694,7 +1759,6 @@
                 ],
                 "visualization": "stat",
                 "statSettings": {
-                  "valueField": "totalRequestsString",
                   "valueAggregation": "None",
                   "colorSettings": {
                     "type": "static",
@@ -1705,12 +1769,18 @@
                   "iconSettings": {
                     "thresholdsGrid": []
                   },
+                  "numberFormatSettings": {
+                    "unit": 0,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  },
                   "tagText": "",
                   "valueFontStyle": "auto"
                 }
               },
-              "customWidth": "25",
-              "name": "❌ Cancellazioni anomale (RJCT imprevisto)",
+              "customWidth": "50",
+              "name": "✅ Callback CNCL — CANCEL confermati",
               "styleSettings": {
                 "showBorder": true
               }
@@ -1719,19 +1789,38 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Start processing INVALID update\"\n    or Message startswith \"Start processing EXPIRED update\"\n| extend\n    event_type = extract(@\"Start processing (\\w+) update\", 1, Message),\n    rtp_id = extract(@\"rtpId=([^,\\s]+)\", 1, Message)\n| summarize\n    [\"Totale\"] = count()\n    by [\"Tipo evento GPD\"] = event_type\n| sort by [\"Totale\"] desc",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Triggering ERROR_CANCEL transition for RTP\"\n| summarize errorCount = count()\n| extend totalRequestsString = tostring(errorCount)",
                 "size": 0,
-                "title": "Cancellazioni per evento GPD (INVALID / EXPIRED)",
-                "noDataMessageStyle": 3,
+                "title": "❌ Callback RJCR — CANCEL rifiutati",
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
                 ],
-                "visualization": "table"
+                "visualization": "stat",
+                "statSettings": {
+                  "valueAggregation": "None",
+                  "colorSettings": {
+                    "type": "static",
+                    "mode": "background",
+                    "heatmapPalette": "greenRed",
+                    "thresholdsGrid": []
+                  },
+                  "iconSettings": {
+                    "thresholdsGrid": []
+                  },
+                  "numberFormatSettings": {
+                    "unit": 0,
+                    "options": {
+                      "style": "decimal"
+                    }
+                  },
+                  "tagText": "",
+                  "valueFontStyle": "auto"
+                }
               },
               "customWidth": "50",
-              "name": "Cancellazioni per evento GPD (INVALID / EXPIRED)",
+              "name": "❌ Callback RJCR — CANCEL rifiutati",
               "styleSettings": {
                 "showBorder": true
               }
@@ -1740,19 +1829,17 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Error cancel RTP:\"\n    or Message startswith \"Error cancelling draft RTP:\"\n| extend _err = trim(\" \", coalesce(\n    replace_string(Message, \"Error cancel RTP:\", \"\"),\n    replace_string(Message, \"Error cancelling draft RTP:\", \"\")\n))\n| extend Categoria = case(\n    _err contains \"imout\" or _err contains \"Timeout\",    \"Timeout\",\n    _err contains \"400\"   or _err contains \"Bad Request\", \"4xx Service Provider\",\n    _err contains \"500\"   or _err contains \"Server Error\",\"5xx Service Provider\",\n    _err contains \"not found\" or _err contains \"404\",     \"RTP non trovato\",\n    _err contains \"MongoWrite\" or _err contains \"Mongo\",  \"Errore DB Mongo\",\n    \"Altro / non classificato\"\n)\n| summarize Errori = count() by Categoria\n| sort by Errori desc",
+                "query": "AppTraces\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where (Message startswith \"Extraction error:\" or Message startswith \"No valid confirmation status found\")\n| extend TipoErrore = case(\n    Message startswith \"Extraction error:\", \"❌ Estrazione campo fallita\",\n    \"⚠️ Status di conferma non trovato\"\n)\n| project\n    TimeGenerated,\n    TipoErrore,\n    debtor_service_provider = Properties[\"debtor_service_provider\"],\n    resource_id             = Properties[\"resource_id\"],\n    correlation_id          = Properties[\"correlation_id\"],\n    Message\n| top 100 by TimeGenerated desc",
                 "size": 0,
-                "title": "Classificazione errori di cancellazione per tipo",
+                "title": "❌ Callback cancellazioni — errori parsing",
                 "noDataMessageStyle": 3,
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "piechart"
+                ]
               },
-              "customWidth": "50",
-              "name": "Classificazione errori di cancellazione per tipo",
+              "name": "❌ Callback cancellazioni — errori parsing",
               "styleSettings": {
                 "showBorder": true
               }
@@ -1761,7 +1848,7 @@
               "type": 3,
               "content": {
                 "version": "KqlItem/1.0",
-                "query": "AppExceptions\n| where AppRoleName == 'rtp-sender'\n| where TimeGenerated {evaluation_window:query}\n| where ExceptionType !contains \"WebClientResponseException\"\n| summarize\n    [\"Occorrenze\"] = count(),\n    [\"Ultimo messaggio\"] = arg_max(TimeGenerated, OuterMessage)\n    by [\"Tipo eccezione\"] = ExceptionType\n| sort by [\"Occorrenze\"] desc",
+                "query": "AppExceptions\n| where TimeGenerated {evaluation_window:query}\n| where AppRoleName == 'rtp-sender'\n| where (\n    OuterMessage contains \"cancel\" or OuterMessage contains \"Cancel\"\n    or OuterMessage contains \"DELETE\" or OuterMessage contains \"cancell\"\n    or InnermostType contains \"Cancel\" or InnermostType contains \"Delete\"\n)\n| project\n    TimeGenerated,\n    InnermostType,\n    OuterMessage,\n    resource_id             = tostring(Properties[\"resource_id\"]),\n    debtor_service_provider = tostring(Properties[\"debtor_service_provider\"]),\n    ExceptionType\n| top 100 by TimeGenerated desc",
                 "size": 0,
                 "title": "Eccezioni Java rtp-sender — flusso cancellazione",
                 "noDataMessageStyle": 3,
@@ -1769,11 +1856,28 @@
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
-                ],
-                "visualization": "table"
+                ]
               },
-              "customWidth": "50",
               "name": "Eccezioni Java rtp-sender — flusso cancellazione",
+              "styleSettings": {
+                "showBorder": true
+              }
+            },
+            {
+              "type": 3,
+              "content": {
+                "version": "KqlItem/1.0",
+                "query": "AppTraces\n| where AppRoleName == \"rtp-sender\"\n| where TimeGenerated {evaluation_window:query}\n| where Message startswith \"Retries exhausted after attempts\"\n| extend ServiceProvider = tostring(Properties.debtor_service_provider)\n| extend ServiceProvider = iff(isempty(ServiceProvider), \"N/A\", ServiceProvider)\n| summarize retries = count() by ServiceProvider\n| order by retries desc",
+                "size": 0,
+                "title": "Retry per cancellazioni SRTP — per Service Provider",
+                "noDataMessageStyle": 3,
+                "queryType": 0,
+                "resourceType": "microsoft.operationalinsights/workspaces",
+                "crossComponentResources": [
+                  "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
+                ]
+              },
+              "name": "Retry per cancellazioni SRTP — per Service Provider",
               "styleSettings": {
                 "showBorder": true
               }

--- a/src/70_domains/srtp_common/workbooks/tabs/invii-srtp.json.tpl
+++ b/src/70_domains/srtp_common/workbooks/tabs/invii-srtp.json.tpl
@@ -623,21 +623,7 @@
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
                 ],
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
+                "visualization": "table"
               },
               "name": "❌ Retry esauriti Consumer → Sender - Copy",
               "styleSettings": {
@@ -843,7 +829,7 @@
                 "version": "KqlItem/1.0",
                 "query": " AppTraces\n | where AppRoleName == 'rtp-sender'\n | where TimeGenerated {evaluation_window:query}\n | where SeverityLevel == 3\n | where Message startswith \"Send RTP request rejected for\"\n | extend service_provider = extract(@\"Send RTP request rejected for ([^:]+):\", 1, Message)\n | extend rtp_operation_id = extract(@\"RTP Id:\\s*(\\d+)\", 1, Message)\n | project\n     TimeGenerated,\n     service_provider,\n     rtp_operation_id,\n     correlation_id = Properties[\"correlation_id\"],\n     resource_id    = Properties[\"resource_id\"]\n | top 100 by TimeGenerated desc",
                 "size": 0,
-                "title": "✅ Invii totali con successo (APIM + CODA)",
+                "title": "❌ RTP rifiutati dal Service Provider - Dettaglio",
                 "queryType": 0,
                 "resourceType": "microsoft.operationalinsights/workspaces",
                 "crossComponentResources": [
@@ -872,7 +858,7 @@
                 }
               },
               "customWidth": "75",
-              "name": "✅ Invii totali con successo (APIM + CODA)",
+              "name": "❌ RTP rifiutati dal Service Provider - Dettaglio",
               "styleSettings": {
                 "showBorder": true
               }
@@ -926,21 +912,7 @@
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
                 ],
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
+                "visualization": "table"
               },
               "customWidth": "75",
               "name": "❌ Catch-all errori invio",
@@ -961,21 +933,7 @@
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
                 ],
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
+                "visualization": "table"
               },
               "name": "❌ REJECTION esplicita EPC",
               "styleSettings": {
@@ -995,21 +953,7 @@
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
                 ],
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
+                "visualization": "table"
               },
               "name": "❌ Errore Handler post retry",
               "styleSettings": {
@@ -1029,21 +973,7 @@
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
                 ],
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
+                "visualization": "table"
               },
               "name": "❌ Errore nel salvataggio a DB del RTP",
               "styleSettings": {
@@ -1063,21 +993,7 @@
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
                 ],
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
+                "visualization": "table"
               },
               "name": "❌ RTP rifiutati dal Service Provider",
               "styleSettings": {
@@ -1117,21 +1033,7 @@
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
                 ],
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
+                "visualization": "table"
               },
               "name": "❌ Errori inattesi nell'invio",
               "styleSettings": {
@@ -1151,21 +1053,7 @@
                 "crossComponentResources": [
                   "/subscriptions/${subscription_id}/resourceGroups/${prefix}-${env_short}-${location_short}-${domain}-monitoring-rg/providers/Microsoft.OperationalInsights/workspaces/${prefix}-${env_short}-${location_short}-${domain}-law"
                 ],
-                "statSettings": {
-                  "valueField": "totalRequestsString",
-                  "valueAggregation": "None",
-                  "colorSettings": {
-                    "type": "static",
-                    "mode": "background",
-                    "heatmapPalette": "greenRed",
-                    "thresholdsGrid": []
-                  },
-                  "iconSettings": {
-                    "thresholdsGrid": []
-                  },
-                  "tagText": "",
-                  "valueFontStyle": "auto"
-                }
+                "visualization": "table"
               },
               "name": "❌ Errori nel recupero della lista enti dal microservizio",
               "styleSettings": {

--- a/src/70_domains/srtp_common/workbooks/tabs/tabs.json.tpl
+++ b/src/70_domains/srtp_common/workbooks/tabs/tabs.json.tpl
@@ -75,6 +75,14 @@
         "linkLabel": "Autenticazione",
         "subTarget": "autenticazione",
         "style": "link"
+      },
+      {
+        "id": "ad51d1d6-bdde-43fc-b847-0342448ba783",
+        "cellValue": "tab",
+        "linkTarget": "parameter",
+        "linkLabel": "Accessi Get Enti",
+        "subTarget": "getPayees",
+        "style": "link"
       }
     ]
   },


### PR DESCRIPTION
### List of changes

- **New workbook tab "Accessi Get Enti"** (`getPayees.json.tpl`): added a new tab to the SRTP OER Azure Monitor Workbook to monitor access to the `rtp/payees/consents` endpoint. The tab includes:
  - Pie chart of total requests by HTTP status code (via APIM `AzureDiagnostics`)
  - Table of accesses per JWT subject for non-200 responses (joined from `AppDependencies` + `AppRequests` for `rtp-payees`)
  - Time chart of successes vs. failures in 1-hour bins
- **New tab entry** registered in `tabs.json.tpl` and `13_workbooks.tf` to expose the new tab in the workbook navigation.
- **"Autenticazione" tab** (`autenticazione.json.tpl`): added a new KQL panel "Panoramica stacco del token (Metriche Keycloak)" that shows token issuance stats (client ID, event type, error, count, first/last emission) from `AppMetrics`, filtered to the `srtp` Keycloak realm.
- **"Invii SRTP / Consumer" tab** (`invii-srtp.json.tpl`):
  - Enhanced the "Retry esauriti Consumer → Sender" KQL query to extract `message_id` from the log message and join with payload and error traces, producing a detailed table (Message ID, attempts, operation, GPD status, EC tax code, debtor tax code, IUV, error) for easier incident investigation.
  - Replaced the simple stat counter for "Messaggi ricevuti dal Sender tramite Consumer" with a breakdown of successful sends per debtor Service Provider.
- **"Activator" tab** (`activator.json.tpl`):
  - Reordered `crossComponentResources` so the domain-scoped Log Analytics workspace is listed first (fixes query context priority).
  - Fixed the KQL query for "Mismatch del Service Provider tra Token e Body" to use the updated log message pattern and extract `sub_token` from structured `Properties` instead of a regex on the raw message.

### Motivation and context

The SRTP OER workbook is used by the operations team to monitor the RTP platform in near-real time. This update improves observability in three areas:

1. **Get Payees endpoint monitoring**: a new `rtp-payees` service was introduced and there was no dedicated workbook tab to track its traffic, error rates, or per-client usage patterns.
2. **Keycloak authentication visibility**: token issuance metrics were not surfaced in the workbook, making it hard to diagnose authentication failures without querying Log Analytics directly.
3. **Consumer retry diagnostics**: the existing "retry exhausted" counter gave no actionable detail. The updated query surfaces the full context of each failed message so on-call engineers can identify the affected payment without searching raw logs.
4. **Activator query fixes**: two KQL queries were broken due to a stale log message pattern and wrong workspace priority, causing them to return no data.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

All changes are confined to Azure Monitor Workbook JSON templates and the Terraform resource that assembles them (`13_workbooks.tf`). No infrastructure resources are created or destroyed; only the workbook definition is updated.
