### PR TITLE
feat: [SRTP-1768] add ADX ingest role and streaming ingestion config for rtp-sender

### DIFF
--- a/src/40_platform/00_data.tf
+++ b/src/40_platform/00_data.tf
@@ -33,6 +33,16 @@ data "azurerm_private_dns_zone" "privatelink_servicebus_windows_net" {
   resource_group_name = local.legacy_vnet_core_rg_name
 }
 
+data "azurerm_private_dns_zone" "storage_account_blob" {
+  name                = "privatelink.blob.core.windows.net"
+  resource_group_name = local.legacy_vnet_core_rg_name
+}
+
+data "azurerm_private_dns_zone" "storage_account_queue" {
+  name                = "privatelink.queue.core.windows.net"
+  resource_group_name = local.legacy_vnet_core_rg_name
+}
+
 data "azurerm_private_dns_zone" "storage_account_table" {
   name                = "privatelink.table.core.windows.net"
   resource_group_name = local.legacy_vnet_core_rg_name

--- a/src/40_platform/71_dataexplorer.tf
+++ b/src/40_platform/71_dataexplorer.tf
@@ -48,6 +48,12 @@ resource "azurerm_private_endpoint" "kusto" {
     is_manual_connection           = false
     subresource_names              = ["cluster"]
   }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [for zone in local.kusto_private_dns_zones : zone.id]
+  }
+
   tags = module.tag_config.tags
 }
 

--- a/src/40_platform/99_locals.tf
+++ b/src/40_platform/99_locals.tf
@@ -219,6 +219,13 @@ locals {
     ])
   }
 
+  kusto_private_dns_zones = [
+    data.azurerm_private_dns_zone.kusto,
+    data.azurerm_private_dns_zone.storage_account_blob,
+    data.azurerm_private_dns_zone.storage_account_queue,
+    data.azurerm_private_dns_zone.storage_account_table,
+  ]
+
   db_group_flatten = flatten([
     for project, db_list in local.adx_databases : [
       for db_name in db_list : [

--- a/src/40_platform/README.md
+++ b/src/40_platform/README.md
@@ -103,6 +103,8 @@
 | [azurerm_private_dns_zone.internal](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.kusto](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.privatelink_servicebus_windows_net](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
+| [azurerm_private_dns_zone.storage_account_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
+| [azurerm_private_dns_zone.storage_account_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.storage_account_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 | [azurerm_user_assigned_identity.iac_federated_azdo](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |

--- a/src/70_domains/srtp_common/00_data.tf
+++ b/src/70_domains/srtp_common/00_data.tf
@@ -100,6 +100,22 @@ data "azurerm_private_dns_zone" "blob_storage" {
   resource_group_name = local.vnet_legacy_core_rg
 }
 
+data "azurerm_private_dns_zone" "queue_storage" {
+  name                = "privatelink.queue.core.windows.net"
+  resource_group_name = local.vnet_legacy_core_rg
+}
+
+data "azurerm_private_dns_zone" "table_storage" {
+  name                = "privatelink.table.core.windows.net"
+  resource_group_name = local.vnet_legacy_core_rg
+}
+
+data "azurerm_private_dns_zone" "kusto" {
+  name                = "privatelink.${var.location}.kusto.windows.net"
+  resource_group_name = "cstar-d-itn-core-network-rg"
+}
+
+
 data "azurerm_private_dns_zone" "file_storage" {
   name                = "privatelink.file.core.windows.net"
   resource_group_name = local.network_rg

--- a/src/70_domains/srtp_common/00_data.tf
+++ b/src/70_domains/srtp_common/00_data.tf
@@ -112,7 +112,7 @@ data "azurerm_private_dns_zone" "table_storage" {
 
 data "azurerm_private_dns_zone" "kusto" {
   name                = "privatelink.${var.location}.kusto.windows.net"
-  resource_group_name = "cstar-d-itn-core-network-rg"
+  resource_group_name = local.network_rg
 }
 
 

--- a/src/70_domains/srtp_common/62_dataexplorer.tf
+++ b/src/70_domains/srtp_common/62_dataexplorer.tf
@@ -72,3 +72,40 @@ resource "azurerm_kusto_database_principal_assignment" "rtp_sender_adx_ingestor"
   tenant_id      = data.azurerm_client_config.current.tenant_id
   role           = "Ingestor"
 }
+
+resource "azapi_resource" "kusto_pe_dns_zone_group" {
+  type      = "Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01"
+  name      = "default"
+  parent_id = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/cstar-d-itn-platform-data-rg/providers/Microsoft.Network/privateEndpoints/cstar-d-itn-platform-prv-endpoint-kusto"
+
+  body = {
+    properties = {
+      privateDnsZoneConfigs = [
+        {
+          name = "kusto"
+          properties = {
+            privateDnsZoneId = data.azurerm_private_dns_zone.kusto.id
+          }
+        },
+        {
+          name = "blob"
+          properties = {
+            privateDnsZoneId = data.azurerm_private_dns_zone.blob_storage.id
+          }
+        },
+        {
+          name = "queue"
+          properties = {
+            privateDnsZoneId = data.azurerm_private_dns_zone.queue_storage.id
+          }
+        },
+        {
+          name = "table"
+          properties = {
+            privateDnsZoneId = data.azurerm_private_dns_zone.table_storage.id
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/70_domains/srtp_common/62_dataexplorer.tf
+++ b/src/70_domains/srtp_common/62_dataexplorer.tf
@@ -60,3 +60,15 @@ resource "azurerm_kusto_database_principal_assignment" "rtp_sender_adx_viewer" {
   tenant_id      = data.azurerm_client_config.current.tenant_id
   role           = "Viewer"
 }
+
+resource "azurerm_kusto_database_principal_assignment" "rtp_sender_adx_ingestor" {
+  name                = "rtp-role-ingestor"
+  resource_group_name = data.azurerm_kusto_cluster.kusto_cluster.resource_group_name
+  cluster_name        = data.azurerm_kusto_cluster.kusto_cluster.name
+  database_name       = azurerm_kusto_database.db[var.domain].name
+
+  principal_id   = data.azurerm_user_assigned_identity.rtp_sender_workload_identity.client_id
+  principal_type = "App"
+  tenant_id      = data.azurerm_client_config.current.tenant_id
+  role           = "Ingestor"
+}

--- a/src/70_domains/srtp_common/62_dataexplorer.tf
+++ b/src/70_domains/srtp_common/62_dataexplorer.tf
@@ -72,22 +72,3 @@ resource "azurerm_kusto_database_principal_assignment" "rtp_sender_adx_ingestor"
   tenant_id      = data.azurerm_client_config.current.tenant_id
   role           = "Ingestor"
 }
-
-resource "azapi_resource" "kusto_pe_dns_zone_group" {
-  type      = "Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01"
-  name      = "default"
-  parent_id = local.kusto_private_endpoint_id
-
-  body = {
-    properties = {
-      privateDnsZoneConfigs = [
-        for name, zone_id in local.kusto_private_dns_zones : {
-          name = name
-          properties = {
-            privateDnsZoneId = zone_id
-          }
-        }
-      ]
-    }
-  }
-}

--- a/src/70_domains/srtp_common/62_dataexplorer.tf
+++ b/src/70_domains/srtp_common/62_dataexplorer.tf
@@ -76,33 +76,15 @@ resource "azurerm_kusto_database_principal_assignment" "rtp_sender_adx_ingestor"
 resource "azapi_resource" "kusto_pe_dns_zone_group" {
   type      = "Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-11-01"
   name      = "default"
-  parent_id = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/cstar-d-itn-platform-data-rg/providers/Microsoft.Network/privateEndpoints/cstar-d-itn-platform-prv-endpoint-kusto"
+  parent_id = local.kusto_private_endpoint_id
 
   body = {
     properties = {
       privateDnsZoneConfigs = [
-        {
-          name = "kusto"
+        for name, zone_id in local.kusto_private_dns_zones : {
+          name = name
           properties = {
-            privateDnsZoneId = data.azurerm_private_dns_zone.kusto.id
-          }
-        },
-        {
-          name = "blob"
-          properties = {
-            privateDnsZoneId = data.azurerm_private_dns_zone.blob_storage.id
-          }
-        },
-        {
-          name = "queue"
-          properties = {
-            privateDnsZoneId = data.azurerm_private_dns_zone.queue_storage.id
-          }
-        },
-        {
-          name = "table"
-          properties = {
-            privateDnsZoneId = data.azurerm_private_dns_zone.table_storage.id
+            privateDnsZoneId = zone_id
           }
         }
       ]

--- a/src/70_domains/srtp_common/99_locals.tf
+++ b/src/70_domains/srtp_common/99_locals.tf
@@ -222,4 +222,18 @@ locals {
     ] : []
   ])
 
+  kusto_private_endpoint_name = "${local.project_no_domain}-platform-prv-endpoint-kusto"
+  kusto_private_endpoint_id = format(
+    "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateEndpoints/%s",
+    data.azurerm_subscription.current.subscription_id,
+    local.kusto_cluster_rg_name,
+    local.kusto_private_endpoint_name
+  )
+  kusto_private_dns_zones = {
+    kusto = data.azurerm_private_dns_zone.kusto.id
+    blob  = data.azurerm_private_dns_zone.blob_storage.id
+    queue = data.azurerm_private_dns_zone.queue_storage.id
+    table = data.azurerm_private_dns_zone.table_storage.id
+  }
+
 }

--- a/src/70_domains/srtp_common/99_locals.tf
+++ b/src/70_domains/srtp_common/99_locals.tf
@@ -222,18 +222,4 @@ locals {
     ] : []
   ])
 
-  kusto_private_endpoint_name = "${local.project_no_domain}-platform-prv-endpoint-kusto"
-  kusto_private_endpoint_id = format(
-    "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateEndpoints/%s",
-    data.azurerm_subscription.current.subscription_id,
-    local.kusto_cluster_rg_name,
-    local.kusto_private_endpoint_name
-  )
-  kusto_private_dns_zones = {
-    kusto = data.azurerm_private_dns_zone.kusto.id
-    blob  = data.azurerm_private_dns_zone.blob_storage.id
-    queue = data.azurerm_private_dns_zone.queue_storage.id
-    table = data.azurerm_private_dns_zone.table_storage.id
-  }
-
 }

--- a/src/70_domains/srtp_common/README.md
+++ b/src/70_domains/srtp_common/README.md
@@ -53,7 +53,6 @@
 |------|------|
 | [argocd_project.domain_project](https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/project) | resource |
 | [azapi_resource.create_tables_srtp](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) | resource |
-| [azapi_resource.kusto_pe_dns_zone_group](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) | resource |
 | [azapi_resource_action.cosmos_approve_pe](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource_action) | resource |
 | [azurerm_api_management_logger.apim_logger](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_logger) | resource |
 | [azurerm_application_insights.srtp_application_insights](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |

--- a/src/70_domains/srtp_common/README.md
+++ b/src/70_domains/srtp_common/README.md
@@ -53,6 +53,7 @@
 |------|------|
 | [argocd_project.domain_project](https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/project) | resource |
 | [azapi_resource.create_tables_srtp](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) | resource |
+| [azapi_resource.kusto_pe_dns_zone_group](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) | resource |
 | [azapi_resource_action.cosmos_approve_pe](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource_action) | resource |
 | [azurerm_api_management_logger.apim_logger](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_logger) | resource |
 | [azurerm_application_insights.srtp_application_insights](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
@@ -154,7 +155,10 @@
 | [azurerm_private_dns_zone.container_apps](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.cosmos_mongo](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.file_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
+| [azurerm_private_dns_zone.kusto](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
+| [azurerm_private_dns_zone.queue_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
+| [azurerm_private_dns_zone.table_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_public_ip.nat_ips](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
 | [azurerm_resource_group.compute_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.platform_data](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/src/70_domains/srtp_common/README.md
+++ b/src/70_domains/srtp_common/README.md
@@ -157,8 +157,8 @@
 | [azurerm_private_dns_zone.cosmos_mongo](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.file_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.kusto](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
+| [azurerm_private_dns_zone.managed_redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.queue_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
-| [azurerm_private_dns_zone.redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_private_dns_zone.table_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_public_ip.nat_ips](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
 | [azurerm_resource_group.compute_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/src/70_domains/srtp_common/README.md
+++ b/src/70_domains/srtp_common/README.md
@@ -76,6 +76,7 @@
 | [azurerm_key_vault_secret.keycloak_url_srtp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.secrets_redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_kusto_database.db](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kusto_database) | resource |
+| [azurerm_kusto_database_principal_assignment.rtp_sender_adx_ingestor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kusto_database_principal_assignment) | resource |
 | [azurerm_kusto_database_principal_assignment.rtp_sender_adx_viewer](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kusto_database_principal_assignment) | resource |
 | [azurerm_log_analytics_workspace.log_analytics_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_private_dns_a_record.ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |

--- a/src/70_domains/srtp_common/data_explorer_kql/create_tables_srtp.kql
+++ b/src/70_domains/srtp_common/data_explorer_kql/create_tables_srtp.kql
@@ -31,3 +31,43 @@
     precStatus: string,
     triggerEvent: string
 )
+
+.create-or-alter table Rtps ingestion json mapping 'RtpsMapping'
+'['
+'{"column":"_id","path":"$._id","datatype":"string"},'
+'{"column":"noticeNumber","path":"$.noticeNumber","datatype":"string"},'
+'{"column":"amount","path":"$.amount","datatype":"decimal"},'
+'{"column":"description","path":"$.description","datatype":"string"},'
+'{"column":"expiryDate","path":"$.expiryDate","datatype":"datetime"},'
+'{"column":"payerName","path":"$.payerName","datatype":"string"},'
+'{"column":"payerId","path":"$.payerId","datatype":"string"},'
+'{"column":"payeeName","path":"$.payeeName","datatype":"string"},'
+'{"column":"payeeId","path":"$.payeeId","datatype":"string"},'
+'{"column":"subject","path":"$.subject","datatype":"string"},'
+'{"column":"savingDateTime","path":"$.savingDateTime","datatype":"datetime"},'
+'{"column":"serviceProviderDebtor","path":"$.serviceProviderDebtor","datatype":"string"},'
+'{"column":"iban","path":"$.iban","datatype":"string"},'
+'{"column":"payTrxRef","path":"$.payTrxRef","datatype":"string"},'
+'{"column":"flgConf","path":"$.flgConf","datatype":"string"},'
+'{"column":"status","path":"$.status","datatype":"string"},'
+'{"column":"serviceProviderCreditor","path":"$.serviceProviderCreditor","datatype":"string"},'
+'{"column":"operationId","path":"$.operationId","datatype":"long"},'
+'{"column":"eventDispatcher","path":"$.eventDispatcher","datatype":"string"},'
+'{"column":"operationDispatcherKey","path":"$.operationDispatcherKey","datatype":"string"}'
+']'
+
+.create-or-alter table RtpEvents ingestion json mapping 'RtpEventsMapping'
+'['
+'{"column":"_id","path":"$._id","datatype":"string"},'
+'{"column":"rtpResourceId","path":"$.rtpResourceId","datatype":"string"},'
+'{"column":"timestamp","path":"$.timestamp","datatype":"datetime"},'
+'{"column":"rtpSavingDateTime","path":"$.rtpSavingDateTime","datatype":"datetime"},'
+'{"column":"eventDispatcher","path":"$.eventDispatcher","datatype":"string"},'
+'{"column":"foreignStatus","path":"$.foreignStatus","datatype":"string"},'
+'{"column":"precStatus","path":"$.precStatus","datatype":"string"},'
+'{"column":"triggerEvent","path":"$.triggerEvent","datatype":"string"}'
+']'
+
+.alter table Rtps policy streamingingestion enable
+
+.alter table RtpEvents policy streamingingestion enable


### PR DESCRIPTION
### List of changes

- Added JSON ingestion mappings (`RtpsMapping`, `RtpEventsMapping`) for the existing `Rtps` and `RtpEvents` ADX tables
- Enabled streaming ingestion policy on both tables (`.alter table ... policy streamingingestion enable`)
- Added `Ingestor` database role assignment for the `rtp-sender` workload identity on the ADX database
- Added private DNS zone data sources for `queue.core.windows.net`, `table.core.windows.net`, and `kusto.windows.net`
- Added locals for the Kusto private endpoint ID and DNS zone map (kusto, blob, queue, table)
- Added `azapi_resource` to configure the private DNS zone group on the existing Kusto private endpoint

### Motivation and context

The `rtp-sender` service needs to ingest data directly into Azure Data Explorer (Kusto) using the Kusto SDK with managed streaming ingestion. Prior to this change, the workload identity only had the `Viewer` role, preventing any write operations. Additionally, the Kusto private endpoint was missing its DNS zone group configuration, which would have caused name resolution failures from within the AKS cluster.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->