### PR TITLE
fix: MMC-673 number of citizen with more than 1 tpp active on grafana dashboard

### DIFF
--- a/src/49_grafanaconf/env/itn-dev/dashboard/mdc/monitoring-mdc.json
+++ b/src/49_grafanaconf/env/itn-dev/dashboard/mdc/monitoring-mdc.json
@@ -714,7 +714,7 @@
             }
           },
           "pluginVersion": "7.2.2",
-          "query": "CitizenMetricsSnapshot\r\n| extend consents_dynamic = todynamic(consents)\r\n| extend consent_keys = bag_keys(consents_dynamic)\r\n| mv-expand key = consent_keys to typeof(string)\r\n| extend consent_obj = consents_dynamic[key]\r\n| extend tppState = tobool(consent_obj[\"tppState\"])\r\n| extend tcDate_ms = tolong(consent_obj[\"tcDate\"][\"$date\"])\r\n| extend tppDate = datetime(1970-01-01) + totimespan(tcDate_ms * 1ms)\r\n| where $__timeFilter(tppDate)\r\n| summarize has_any_true = countif(tppState == true) by fiscal_code\r\n| summarize ['Cittadini con consenso'] = countif(has_any_true == 1)",
+          "query": "CitizenMetricsSnapshot\r\n| extend consents_dynamic = todynamic(consents)\r\n| extend consent_keys = bag_keys(consents_dynamic)\r\n| mv-expand key = consent_keys to typeof(string)\r\n| extend consent_obj = consents_dynamic[key]\r\n| extend tppState = tobool(consent_obj[\"tppState\"])\r\n| extend tcDate_ms = tolong(consent_obj[\"tcDate\"][\"$date\"])\r\n| extend tppDate = datetime(1970-01-01) + totimespan(tcDate_ms * 1ms)\r\n| where $__timeFilter(tppDate)\r\n| summarize has_any_true = countif(tppState == true) by fiscal_code\r\n| summarize ['Cittadini con consenso'] = countif(has_any_true >= 1)",
           "querySource": "raw",
           "queryType": "KQL",
           "rawMode": true,
@@ -892,5 +892,5 @@
   "timezone": "utc",
   "title": "Monitoraggio MDC",
   "uid": "efj6fhop10um8c",
-  "version": 26
+  "version": 27
 }

--- a/src/49_grafanaconf/env/itn-prod/dashboard/mdc/monitoring-mdc.json
+++ b/src/49_grafanaconf/env/itn-prod/dashboard/mdc/monitoring-mdc.json
@@ -714,7 +714,7 @@
             }
           },
           "pluginVersion": "7.2.2",
-          "query": "CitizenMetricsSnapshot\r\n| extend consents_dynamic = todynamic(consents)\r\n| extend consent_keys = bag_keys(consents_dynamic)\r\n| mv-expand key = consent_keys to typeof(string)\r\n| extend consent_obj = consents_dynamic[key]\r\n| extend tppState = tobool(consent_obj[\"tppState\"])\r\n| extend tcDate_ms = tolong(consent_obj[\"tcDate\"][\"$date\"])\r\n| extend tppDate = datetime(1970-01-01) + totimespan(tcDate_ms * 1ms)\r\n| where $__timeFilter(tppDate)\r\n| summarize has_any_true = countif(tppState == true) by fiscal_code\r\n| summarize ['Cittadini con consenso'] = countif(has_any_true == 1)",
+          "query": "CitizenMetricsSnapshot\r\n| extend consents_dynamic = todynamic(consents)\r\n| extend consent_keys = bag_keys(consents_dynamic)\r\n| mv-expand key = consent_keys to typeof(string)\r\n| extend consent_obj = consents_dynamic[key]\r\n| extend tppState = tobool(consent_obj[\"tppState\"])\r\n| extend tcDate_ms = tolong(consent_obj[\"tcDate\"][\"$date\"])\r\n| extend tppDate = datetime(1970-01-01) + totimespan(tcDate_ms * 1ms)\r\n| where $__timeFilter(tppDate)\r\n| summarize has_any_true = countif(tppState == true) by fiscal_code\r\n| summarize ['Cittadini con consenso'] = countif(has_any_true >= 1)",
           "querySource": "raw",
           "queryType": "KQL",
           "rawMode": true,
@@ -892,5 +892,5 @@
   "timezone": "utc",
   "title": "Monitoraggio MDC",
   "uid": "efj6fhop10um8c",
-  "version": 26
+  "version": 27
 }

--- a/src/49_grafanaconf/env/itn-uat/dashboard/mdc/monitoring-mdc.json
+++ b/src/49_grafanaconf/env/itn-uat/dashboard/mdc/monitoring-mdc.json
@@ -714,7 +714,7 @@
             }
           },
           "pluginVersion": "7.2.2",
-          "query": "CitizenMetricsSnapshot\r\n| extend consents_dynamic = todynamic(consents)\r\n| extend consent_keys = bag_keys(consents_dynamic)\r\n| mv-expand key = consent_keys to typeof(string)\r\n| extend consent_obj = consents_dynamic[key]\r\n| extend tppState = tobool(consent_obj[\"tppState\"])\r\n| extend tcDate_ms = tolong(consent_obj[\"tcDate\"][\"$date\"])\r\n| extend tppDate = datetime(1970-01-01) + totimespan(tcDate_ms * 1ms)\r\n| where $__timeFilter(tppDate)\r\n| summarize has_any_true = countif(tppState == true) by fiscal_code\r\n| summarize ['Cittadini con consenso'] = countif(has_any_true == 1)",
+          "query": "CitizenMetricsSnapshot\r\n| extend consents_dynamic = todynamic(consents)\r\n| extend consent_keys = bag_keys(consents_dynamic)\r\n| mv-expand key = consent_keys to typeof(string)\r\n| extend consent_obj = consents_dynamic[key]\r\n| extend tppState = tobool(consent_obj[\"tppState\"])\r\n| extend tcDate_ms = tolong(consent_obj[\"tcDate\"][\"$date\"])\r\n| extend tppDate = datetime(1970-01-01) + totimespan(tcDate_ms * 1ms)\r\n| where $__timeFilter(tppDate)\r\n| summarize has_any_true = countif(tppState == true) by fiscal_code\r\n| summarize ['Cittadini con consenso'] = countif(has_any_true >= 1)",
           "querySource": "raw",
           "queryType": "KQL",
           "rawMode": true,
@@ -892,5 +892,5 @@
   "timezone": "utc",
   "title": "Monitoraggio MDC",
   "uid": "efj6fhop10um8c",
-  "version": 26
+  "version": 27
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
-change of query to take citizend that one or more tpp active

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
now was showing only the citizen with 1 tpp active on the dashboard giving the wrong numeber of metric

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources
- [x] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
