### PR TITLE
feat: SRTP-1905 add GPD Message API alert configurations for 4xx and 5xx errors

### DIFF
--- a/src/70_domains/srtp_app/00_data.tf
+++ b/src/70_domains/srtp_app/00_data.tf
@@ -22,6 +22,11 @@ data "azurerm_log_analytics_workspace" "log_analytics_workspace" {
   resource_group_name = local.monitoring_rg
 }
 
+data "azurerm_log_analytics_workspace" "core_log_analytics_workspace" {
+  name                = "${var.prefix}-${var.env_short}-law"
+  resource_group_name = "${var.prefix}-${var.env_short}-monitor-rg"
+}
+
 #
 # RG
 #

--- a/src/70_domains/srtp_app/12_alerts_locals.tf
+++ b/src/70_domains/srtp_app/12_alerts_locals.tf
@@ -119,6 +119,57 @@ locals {
       ])
       email_subject = "[RTP-CONSUMER][WARNING] 0 messages consumed by rtp-consumer in the last 30 minutes"
     }
+
+    # 🚨 GPD Message API 4xx Error
+    rtp_gpd_message_4xx_alert = {
+      name           = "rtp-gpd-message-4xx-alert"
+      description    = "Alert when the GPD Message API returns a 4xx error code"
+      severity       = 1
+      frequency      = 5
+      time_window    = 5
+      data_source_id = data.azurerm_log_analytics_workspace.core_log_analytics_workspace.id
+      query          = <<-QUERY
+            AzureDiagnostics
+            | where requestUri_s contains "rtp/gpd/message"
+            | where httpMethod_s == "POST"
+            | where toint(httpStatus_d) >= 400 and toint(httpStatus_d) < 500 and toint(httpStatus_d) != 404
+          QUERY
+      trigger = {
+        operator  = "GreaterThanOrEqual"
+        threshold = 1
+      }
+      # Use both email and slack for this alert
+      action_groups = compact([
+        try(azurerm_monitor_action_group.email[0].id, null),
+        try(azurerm_monitor_action_group.slack[0].id, null)
+      ])
+      email_subject = "[RTP-SENDER] [WARNING] GPD Message API 4xx Error"
+    }
+
+    rtp_gpd_message_5xx_alert = {
+      name           = "rtp-gpd-message-5xx-alert"
+      description    = "Alert when the GPD Message API returns a 5xx error code"
+      severity       = 1
+      frequency      = 5
+      time_window    = 5
+      data_source_id = data.azurerm_log_analytics_workspace.core_log_analytics_workspace.id
+      query          = <<-QUERY
+            AzureDiagnostics
+            | where requestUri_s contains "rtp/gpd/message"
+            | where httpMethod_s == "POST"
+            | where toint(httpStatus_d) >= 500
+          QUERY
+      trigger = {
+        operator  = "GreaterThanOrEqual"
+        threshold = 1
+      }
+      # Use both email and slack for this alert
+      action_groups = compact([
+        try(azurerm_monitor_action_group.email[0].id, null),
+        try(azurerm_monitor_action_group.slack[0].id, null)
+      ])
+      email_subject = "[RTP-SENDER] [CRITICAL] GPD Message API 5xx Error"
+    }
   }
 
   # 🧱 Collection of alert groups

--- a/src/70_domains/srtp_app/README.md
+++ b/src/70_domains/srtp_app/README.md
@@ -55,6 +55,7 @@
 | [azurerm_key_vault_secret.slack_webhook_email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.workload_identity_client_id](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.workload_identity_service_account_name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_log_analytics_workspace.core_log_analytics_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_log_analytics_workspace.log_analytics_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_resource_group.identities_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.monitor_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |


### PR DESCRIPTION
### List of changes

- Added a new `core_log_analytics_workspace` data source for the SRTP application Terraform module, pointing to the core Log Analytics workspace in the monitoring resource group.
- Added two scheduled query alert definitions for the GPD Message API `POST rtp/gpd/message` endpoint:
    - `rtp-gpd-message-4xx-alert`: triggers when the API returns at least one 4xx response, excluding 404, within a 5-minute window.
    - `rtp-gpd-message-5xx-alert`: triggers when the API returns at least one 5xx response within a 5-minute window.
- Configured both alerts to use the core Log Analytics workspace as their data source and notify both email and Slack action groups when available.
- Updated the SRTP application Terraform README to include the newly referenced Log Analytics workspace data source.

### Motivation and context

This change improves observability for the GPD Message API by adding dedicated alerts for client-side and server-side failures on the message submission endpoint.

The new alerts help detect failed `POST` requests to `rtp/gpd/message` quickly, distinguishing warning-level 4xx errors from critical 5xx errors. This enables faster investigation and response when the endpoint starts returning unexpected errors.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

The Terraform plan should be reviewed before applying to confirm that only the expected alerting resources/configuration are created or updated.

---

### If PR is partially applied, why? (reserved to mantainers)

Not applicable.
