### PR TITLE
fix: SRTP-1905 update alert location configuration in GPD Message API

### DIFF
--- a/src/70_domains/srtp_app/12_alerts.tf
+++ b/src/70_domains/srtp_app/12_alerts.tf
@@ -3,7 +3,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alerts" {
 
   name                = each.value.name
   resource_group_name = data.azurerm_resource_group.monitor_rg.name
-  location            = var.location
+  location            = lookup(each.value, "location", var.location)
 
   description = each.value.description
   enabled     = lookup(each.value, "enabled", true)

--- a/src/70_domains/srtp_app/12_alerts_locals.tf
+++ b/src/70_domains/srtp_app/12_alerts_locals.tf
@@ -128,6 +128,7 @@ locals {
       frequency      = 5
       time_window    = 5
       data_source_id = data.azurerm_log_analytics_workspace.core_log_analytics_workspace.id
+      location       = data.azurerm_log_analytics_workspace.core_log_analytics_workspace.location
       query          = <<-QUERY
             AzureDiagnostics
             | where requestUri_s contains "rtp/gpd/message"
@@ -153,6 +154,7 @@ locals {
       frequency      = 5
       time_window    = 5
       data_source_id = data.azurerm_log_analytics_workspace.core_log_analytics_workspace.id
+      location       = data.azurerm_log_analytics_workspace.core_log_analytics_workspace.location
       query          = <<-QUERY
             AzureDiagnostics
             | where requestUri_s contains "rtp/gpd/message"


### PR DESCRIPTION
### List of changes

- Updated the SRTP application scheduled query alert resource so each alert can optionally override its Azure location through a `location` field.
- Kept the existing default behavior unchanged by falling back to `var.location` when no alert-specific location is provided.
- Set the GPD Message API 4xx and 5xx alerts to use the location of the core Log Analytics workspace referenced by their `data_source_id`.

### Motivation and context

The GPD Message API alerts use the core Log Analytics workspace as their data source. Scheduled query alert rules must be created in a location compatible with the workspace they query.

This fix ensures the GPD Message API 4xx and 5xx alerts are deployed in the same location as the core Log Analytics workspace, preventing location mismatches during Terraform apply while preserving the default location behavior for all other alerts.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

Terraform plan should be reviewed before applying to confirm that only the expected scheduled query alert location changes are introduced.

---

### If PR is partially applied, why? (reserved to mantainers)

Not applicable.