### PR TITLE
fix: SRTP-1905 refine alert configuration to filter based on enabled status

### DIFF
--- a/src/70_domains/srtp_app/12_alerts.tf
+++ b/src/70_domains/srtp_app/12_alerts.tf
@@ -3,7 +3,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alerts" {
 
   name                = each.value.name
   resource_group_name = data.azurerm_resource_group.monitor_rg.name
-  location            = lookup(each.value, "location", var.location)
+  location            = try(each.value.location, null) != null ? each.value.location : var.location
 
   description = each.value.description
   enabled     = lookup(each.value, "enabled", true)

--- a/src/70_domains/srtp_app/12_alerts.tf
+++ b/src/70_domains/srtp_app/12_alerts.tf
@@ -1,5 +1,5 @@
 resource "azurerm_monitor_scheduled_query_rules_alert" "alerts" {
-  for_each = var.srtp_alerts_enabled ? local.final_alerts : tomap({})
+  for_each = { for k, v in local.final_alerts : k => v if var.srtp_alerts_enabled }
 
   name                = each.value.name
   resource_group_name = data.azurerm_resource_group.monitor_rg.name

--- a/src/70_domains/srtp_app/12_alerts_locals.tf
+++ b/src/70_domains/srtp_app/12_alerts_locals.tf
@@ -6,6 +6,7 @@ locals {
     frequency      = 5
     time_window    = 5
     data_source_id = data.azurerm_log_analytics_workspace.log_analytics_workspace.id
+    location       = null
   }
 
   alerts_rtp = {


### PR DESCRIPTION

### List of changes

- Updated the SRTP application scheduled query alert `for_each` expression to filter `local.final_alerts` based on `var.srtp_alerts_enabled`.
- Replaced the previous ternary expression returning either `local.final_alerts` or an empty map with a map comprehension that preserves a consistent object type.
- Added a default `location = null` value to `default_alert_settings` so alert configurations have a consistent schema when merged with alert-specific overrides.

### Motivation and context

This change fixes Terraform type consistency issues in the SRTP alert configuration.

The scheduled query alert resource iterates over alert definitions built from shared defaults and alert-specific settings. Using a ternary expression with different object shapes can cause Terraform to fail type validation, especially when optional fields such as `location` are present only on some alerts.

By filtering the alerts with a map comprehension and defining `location` in the default alert settings, all alert objects keep a consistent structure while still allowing alert creation to be disabled through `var.srtp_alerts_enabled`.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

Terraform plan should be reviewed before applying to confirm that the change only affects the alert resource evaluation logic and does not introduce unexpected infrastructure changes.

---

### If PR is partially applied, why? (reserved to mantainers)

Not applicable.