### PR TITLE
fix: SRTP-1908 update GPD Message API alert configurations for 4xx and 5xx errors

### DIFF
--- a/src/70_domains/srtp_app/12_alerts_locals.tf
+++ b/src/70_domains/srtp_app/12_alerts_locals.tf
@@ -124,17 +124,17 @@ locals {
     # 🚨 GPD Message API 4xx Error
     rtp_gpd_message_4xx_alert = {
       name           = "rtp-gpd-message-4xx-alert"
-      description    = "Alert when the GPD Message API returns a 4xx error code"
+      description    = "Alert when the GPD Message API returns a 4xx error code (excluding 404 and 422)"
       severity       = 1
-      frequency      = 5
-      time_window    = 5
+      frequency      = 120
+      time_window    = 120
       data_source_id = data.azurerm_log_analytics_workspace.core_log_analytics_workspace.id
       location       = data.azurerm_log_analytics_workspace.core_log_analytics_workspace.location
       query          = <<-QUERY
             AzureDiagnostics
             | where requestUri_s contains "rtp/gpd/message"
             | where httpMethod_s == "POST"
-            | where toint(httpStatus_d) >= 400 and toint(httpStatus_d) < 500 and toint(httpStatus_d) != 404
+            | where toint(httpStatus_d) >= 400 and toint(httpStatus_d) < 500 and toint(httpStatus_d) != 404 and toint(httpStatus_d) != 422
           QUERY
       trigger = {
         operator  = "GreaterThanOrEqual"
@@ -148,12 +148,13 @@ locals {
       email_subject = "[RTP-SENDER] [WARNING] GPD Message API 4xx Error"
     }
 
+    # 🚨 GPD Message API 5xx Error
     rtp_gpd_message_5xx_alert = {
       name           = "rtp-gpd-message-5xx-alert"
       description    = "Alert when the GPD Message API returns a 5xx error code"
-      severity       = 1
-      frequency      = 5
-      time_window    = 5
+      severity       = 0
+      frequency      = 120
+      time_window    = 120
       data_source_id = data.azurerm_log_analytics_workspace.core_log_analytics_workspace.id
       location       = data.azurerm_log_analytics_workspace.core_log_analytics_workspace.location
       query          = <<-QUERY


### PR DESCRIPTION
### List of changes

- Updated the GPD Message API 4xx alert description to explicitly state that both `404` and `422` responses are excluded.
- Extended the GPD Message API 4xx alert evaluation frequency and time window from 5 minutes to 120 minutes.
- Updated the GPD Message API 4xx alert query to exclude `422` responses in addition to `404` responses.
- Extended the GPD Message API 5xx alert evaluation frequency and time window from 5 minutes to 120 minutes.
- Increased the GPD Message API 5xx alert severity from `1` to `0`, making server-side failures critical.

### Motivation and context

This change tunes the SRTP GPD Message API alerting configuration to better match the expected operational behavior of the endpoint.

`422` responses are now excluded from the 4xx alert because they represent expected validation/business-rule failures and should not generate warning notifications together with unexpected client-side errors. The 4xx alert already excluded `404`; this update makes the exclusion explicit in both the alert description and query.

The alert evaluation period is increased to 120 minutes for both 4xx and 5xx alerts to reduce alert noise and evaluate failures over a broader time window. At the same time, 5xx responses are classified as severity `0` because server-side failures on the GPD Message API require critical attention.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

Terraform plan should be reviewed before applying to confirm that only the expected scheduled query alert configuration changes are introduced.

---

### If PR is partially applied, why? (reserved to mantainers)

Not applicable.