### PR TITLE
feat: [SRTP-1909] Add Managed Identity for SRTP KeyVault

### DIFF
--- a/src/70_domains/srtp_security/00_data.tf
+++ b/src/70_domains/srtp_security/00_data.tf
@@ -39,3 +39,8 @@ data "azurerm_user_assigned_identity" "iac_federated_azdo" {
   name                = each.key
   resource_group_name = local.azdo_managed_identity_rg_name
 }
+
+data "azurerm_user_assigned_identity" "subscription_service_connection" {
+  name                = "${upper(var.env)}-${upper(var.prefix)}"
+  resource_group_name = local.azdo_managed_identity_rg_name
+}

--- a/src/70_domains/srtp_security/02_azdo_config.tf
+++ b/src/70_domains/srtp_security/02_azdo_config.tf
@@ -1,3 +1,15 @@
+resource "azurerm_key_vault_access_policy" "subscription_service_connection_read" {
+  for_each = toset(local.secrets_folders_kv)
+
+  key_vault_id = module.key_vault[each.key].id
+  tenant_id    = data.azurerm_user_assigned_identity.subscription_service_connection.tenant_id
+  object_id    = data.azurerm_user_assigned_identity.subscription_service_connection.principal_id
+
+  key_permissions         = ["Get", "List"]
+  secret_permissions      = ["Get", "List"]
+  certificate_permissions = ["Get", "List"]
+}
+
 resource "azurerm_key_vault_access_policy" "azdevops_iac_managed_identities_read_only" {
   for_each = local.azdo_iac_read_kv
 

--- a/src/70_domains/srtp_security/README.md
+++ b/src/70_domains/srtp_security/README.md
@@ -4,7 +4,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.10.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
@@ -13,7 +13,7 @@
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.53.1 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.54.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.3.5 |
@@ -21,7 +21,7 @@
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | 70693c3d31279e8c2d2b5365223fb551b3cfd112 |
 | <a name="module_admins_policy"></a> [admins\_policy](#module\_admins\_policy) | ./.terraform/modules/__v4__/IDH/key_vault_access_policy | n/a |
 | <a name="module_key_vault"></a> [key\_vault](#module\_key\_vault) | ./.terraform/modules/__v4__/IDH/key_vault | n/a |
@@ -33,7 +33,7 @@
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [azurerm_key_vault_access_policy.azdevops_iac_managed_identities_read_only](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.azdevops_iac_managed_identities_write](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.subscription_service_connection_read](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
@@ -53,7 +53,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | n/a | yes |
 | <a name="input_env"></a> [env](#input\_env) | Environment | `string` | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |

--- a/src/70_domains/srtp_security/README.md
+++ b/src/70_domains/srtp_security/README.md
@@ -4,7 +4,7 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.10.0 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
@@ -13,7 +13,7 @@
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.53.1 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.54.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | 2.3.5 |
@@ -21,7 +21,7 @@
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | 70693c3d31279e8c2d2b5365223fb551b3cfd112 |
 | <a name="module_admins_policy"></a> [admins\_policy](#module\_admins\_policy) | ./.terraform/modules/__v4__/IDH/key_vault_access_policy | n/a |
 | <a name="module_key_vault"></a> [key\_vault](#module\_key\_vault) | ./.terraform/modules/__v4__/IDH/key_vault | n/a |
@@ -33,9 +33,10 @@
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_key_vault_access_policy.azdevops_iac_managed_identities_read_only](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.azdevops_iac_managed_identities_write](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.subscription_service_connection_read](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_key.sops_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_key) | resource |
 | [azurerm_key_vault_secret.sops_local_secrets](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
@@ -46,12 +47,13 @@
 | [azurerm_resource_group.security_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 | [azurerm_user_assigned_identity.iac_federated_azdo](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
+| [azurerm_user_assigned_identity.subscription_service_connection](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) | data source |
 | [external_external.terrasops](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | n/a | yes |
 | <a name="input_env"></a> [env](#input\_env) | Environment | `string` | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |


### PR DESCRIPTION
List of changes
  
  - Added a data source to look up the subscription-level Azure DevOps service connection managed identity `(${ENV}-${PREFIX})` from the existing managed identity resource group.
  - Added a new `azurerm_key_vault_access_policy` resource (`subscription_service_connection_read`) granting that identity **Get/List** permissions on keys, secrets, and certificates across all Key Vaults in `local.secrets_folders_kv`.

  Motivation and context

  The _SRTP_ domain uses _Azure Key Vault_ to store secrets consumed during pipeline execution. 
The subscription-level _Azure DevOps_ service connection (a user-assigned managed identity) needs read access to those Key Vaults to retrieve secrets at runtime. 
Without this policy, pipelines authenticating via the subscription service connection fail to read Key Vault contents.

  Type of changes

  - [x] Add new resources
  - [x] Update configuration to existing resources
  - [ ] Remove existing resources
  - [ ] Chore: change that does not affect functionality

  Env to apply
  
  - [ ] DEV
  - [x] UAT
  - [ ] PROD

  Does this introduce a change to production resources with possible user impact?

  - [ ] Yes, users may be impacted applying this change
  - [x] No

  Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
  
  - [ ] Yes
  - [x] No

  Other information