### PR TITLE
feat: SRTP-1920 add new repo rtp-sender-v2

### DIFF
--- a/src/70_domains/srtp_app/01_identities.tf
+++ b/src/70_domains/srtp_app/01_identities.tf
@@ -49,6 +49,31 @@ resource "azurerm_role_assignment" "storage_account_to_sender_identity" {
 }
 
 # ------------------------------------------------------------------------------
+# Identity for rtp-sender-v2 microservice.
+# ------------------------------------------------------------------------------
+resource "azurerm_user_assigned_identity" "sender_v2" {
+  resource_group_name = data.azurerm_resource_group.identities_rg.name
+  location            = data.azurerm_resource_group.identities_rg.location
+  name                = "${local.project}-sender-v2-id"
+  tags                = module.tag_config.tags
+}
+
+resource "azurerm_key_vault_access_policy" "access_policy_sender_v2_kv" {
+
+  key_vault_id = data.azurerm_key_vault.domain_kv.id
+  tenant_id    = data.azurerm_key_vault.domain_kv.tenant_id
+  object_id    = azurerm_user_assigned_identity.sender_v2.principal_id
+
+  secret_permissions = ["Get", "List"]
+}
+
+resource "azurerm_role_assignment" "storage_account_to_sender_v2_identity" {
+  scope                = data.azurerm_storage_account.rtp_storage_account.id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = azurerm_user_assigned_identity.sender_v2.principal_id
+}
+
+# ------------------------------------------------------------------------------
 # Role Assignment for srtp microservices.
 # ------------------------------------------------------------------------------
 

--- a/src/70_domains/srtp_app/01_identities.tf
+++ b/src/70_domains/srtp_app/01_identities.tf
@@ -52,6 +52,7 @@ resource "azurerm_role_assignment" "storage_account_to_sender_identity" {
 # Identity for rtp-sender-v2 microservice.
 # ------------------------------------------------------------------------------
 resource "azurerm_user_assigned_identity" "sender_v2" {
+  count               = var.env_short != "p" ? 1 : 0
   resource_group_name = data.azurerm_resource_group.identities_rg.name
   location            = data.azurerm_resource_group.identities_rg.location
   name                = "${local.project}-sender-v2-id"
@@ -59,18 +60,19 @@ resource "azurerm_user_assigned_identity" "sender_v2" {
 }
 
 resource "azurerm_key_vault_access_policy" "access_policy_sender_v2_kv" {
-
+  count        = var.env_short != "p" ? 1 : 0
   key_vault_id = data.azurerm_key_vault.domain_kv.id
   tenant_id    = data.azurerm_key_vault.domain_kv.tenant_id
-  object_id    = azurerm_user_assigned_identity.sender_v2.principal_id
+  object_id    = azurerm_user_assigned_identity.sender_v2[0].principal_id
 
   secret_permissions = ["Get", "List"]
 }
 
 resource "azurerm_role_assignment" "storage_account_to_sender_v2_identity" {
+  count                = var.env_short != "p" ? 1 : 0
   scope                = data.azurerm_storage_account.rtp_storage_account.id
   role_definition_name = "Storage Blob Data Reader"
-  principal_id         = azurerm_user_assigned_identity.sender_v2.principal_id
+  principal_id         = azurerm_user_assigned_identity.sender_v2[0].principal_id
 }
 
 # ------------------------------------------------------------------------------

--- a/src/70_domains/srtp_app/01_identities.tf
+++ b/src/70_domains/srtp_app/01_identities.tf
@@ -49,33 +49,6 @@ resource "azurerm_role_assignment" "storage_account_to_sender_identity" {
 }
 
 # ------------------------------------------------------------------------------
-# Identity for rtp-sender-v2 microservice.
-# ------------------------------------------------------------------------------
-resource "azurerm_user_assigned_identity" "sender_v2" {
-  count               = var.env_short != "p" ? 1 : 0
-  resource_group_name = data.azurerm_resource_group.identities_rg.name
-  location            = data.azurerm_resource_group.identities_rg.location
-  name                = "${local.project}-sender-v2-id"
-  tags                = module.tag_config.tags
-}
-
-resource "azurerm_key_vault_access_policy" "access_policy_sender_v2_kv" {
-  count        = var.env_short != "p" ? 1 : 0
-  key_vault_id = data.azurerm_key_vault.domain_kv.id
-  tenant_id    = data.azurerm_key_vault.domain_kv.tenant_id
-  object_id    = azurerm_user_assigned_identity.sender_v2[0].principal_id
-
-  secret_permissions = ["Get", "List"]
-}
-
-resource "azurerm_role_assignment" "storage_account_to_sender_v2_identity" {
-  count                = var.env_short != "p" ? 1 : 0
-  scope                = data.azurerm_storage_account.rtp_storage_account.id
-  role_definition_name = "Storage Blob Data Reader"
-  principal_id         = azurerm_user_assigned_identity.sender_v2[0].principal_id
-}
-
-# ------------------------------------------------------------------------------
 # Role Assignment for srtp microservices.
 # ------------------------------------------------------------------------------
 

--- a/src/70_domains/srtp_app/10_k8s_secrets.tf
+++ b/src/70_domains/srtp_app/10_k8s_secrets.tf
@@ -12,6 +12,20 @@ resource "kubernetes_secret" "fileshare" {
   type = "Opaque"
 }
 
+resource "kubernetes_secret" "rtp_sender_v2_fileshare" {
+  metadata {
+    name      = "rtp-sender-v2-microservice-chart-azure-file"
+    namespace = var.domain
+  }
+
+  data = {
+    azurestorageaccountname = data.azurerm_storage_account.rtp_share_storage_account.name
+    azurestorageaccountkey  = data.azurerm_storage_account.rtp_share_storage_account.primary_access_key
+  }
+
+  type = "Opaque"
+}
+
 resource "kubernetes_secret" "rtp_activator_fileshare" {
   metadata {
     name      = "rtp-activator-microservice-chart-azure-file"

--- a/src/70_domains/srtp_app/10_k8s_secrets.tf
+++ b/src/70_domains/srtp_app/10_k8s_secrets.tf
@@ -13,6 +13,7 @@ resource "kubernetes_secret" "fileshare" {
 }
 
 resource "kubernetes_secret" "rtp_sender_v2_fileshare" {
+  count = var.env_short != "p" ? 1 : 0
   metadata {
     name      = "rtp-sender-v2-microservice-chart-azure-file"
     namespace = var.domain

--- a/src/70_domains/srtp_app/30_argocd_domain.tf
+++ b/src/70_domains/srtp_app/30_argocd_domain.tf
@@ -19,7 +19,7 @@ locals {
         "rtp-sender-v2" = {
           name          = "rtp-sender-v2"
           target_branch = "main"
-          env           = ["dev", "uat", "prod"]
+          env           = ["dev", "uat"]
         }
       },
       {

--- a/src/70_domains/srtp_app/30_argocd_domain.tf
+++ b/src/70_domains/srtp_app/30_argocd_domain.tf
@@ -16,6 +16,13 @@ locals {
         }
       },
       {
+        "rtp-sender-v2" = {
+          name          = "rtp-sender-v2"
+          target_branch = "main"
+          env           = ["dev", "uat", "prod"]
+        }
+      },
+      {
         "rtp-consumer" = {
           name          = "rtp-consumer"
           target_branch = "main"

--- a/src/70_domains/srtp_app/README.md
+++ b/src/70_domains/srtp_app/README.md
@@ -36,6 +36,7 @@
 | [argocd_application.domain_argocd_applications](https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/application) | resource |
 | [azurerm_key_vault_access_policy.access_policy_activator_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.access_policy_sender_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.access_policy_sender_v2_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_action_group.slack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alerts](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
@@ -43,11 +44,14 @@
 | [azurerm_role_assignment.storage_account_to_activator_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.storage_account_to_namespace_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.storage_account_to_sender_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.storage_account_to_sender_v2_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity.activator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.sender](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.sender_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [helm_release.reloader](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_secret.fileshare](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.rtp_activator_fileshare](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.rtp_sender_v2_fileshare](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [azurerm_api_management.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/api_management) | data source |
 | [azurerm_key_vault.domain_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault_secret.argocd_admin_password](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |

--- a/src/70_domains/srtp_app/README.md
+++ b/src/70_domains/srtp_app/README.md
@@ -36,7 +36,6 @@
 | [argocd_application.domain_argocd_applications](https://registry.terraform.io/providers/argoproj-labs/argocd/latest/docs/resources/application) | resource |
 | [azurerm_key_vault_access_policy.access_policy_activator_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.access_policy_sender_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
-| [azurerm_key_vault_access_policy.access_policy_sender_v2_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_action_group.slack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alerts](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
@@ -44,10 +43,8 @@
 | [azurerm_role_assignment.storage_account_to_activator_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.storage_account_to_namespace_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.storage_account_to_sender_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.storage_account_to_sender_v2_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_user_assigned_identity.activator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.sender](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.sender_v2](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [helm_release.reloader](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_secret.fileshare](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.rtp_activator_fileshare](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |

--- a/src/70_domains/srtp_common/99_locals.tf
+++ b/src/70_domains/srtp_common/99_locals.tf
@@ -46,7 +46,7 @@ locals {
   dns_zone_internal                = "internal.${local.dns_zone_name}"
   ingress_private_load_balancer_ip = "10.10.1.250"
 
-  repositories = ["rtp-sender", "rtp-activator", "rtp-consumer", "rtp-payees"]
+  repositories = ["rtp-sender", "rtp-sender-v2", "rtp-activator", "rtp-consumer", "rtp-payees"]
 
   # AKS
   aks_name                = "${local.project_no_domain}-${var.env}-aks"

--- a/src/70_domains/srtp_common/99_locals.tf
+++ b/src/70_domains/srtp_common/99_locals.tf
@@ -46,7 +46,10 @@ locals {
   dns_zone_internal                = "internal.${local.dns_zone_name}"
   ingress_private_load_balancer_ip = "10.10.1.250"
 
-  repositories = ["rtp-sender", "rtp-sender-v2", "rtp-activator", "rtp-consumer", "rtp-payees"]
+  repositories = concat(
+    ["rtp-sender", "rtp-activator", "rtp-consumer", "rtp-payees"],
+    var.env_short != "p" ? ["rtp-sender-v2"] : []
+  )
 
   # AKS
   aks_name                = "${local.project_no_domain}-${var.env}-aks"

--- a/src/91_github/srtp/99_locals.tf
+++ b/src/91_github/srtp/99_locals.tf
@@ -39,6 +39,18 @@ locals {
       ]
       repository_variables = []
     }
+    rtp-sender-v2 = {
+      env_variables        = [],
+      env_secret_variables = []
+      repository_secrets = [
+        {
+          SLACK_WEBHOOK_URL = data.azurerm_key_vault_secret.slack_webhook.value
+          GIT_PAT           = try(data.azurerm_key_vault_secret.git_pat[0].value, "")
+          SONAR_TOKEN       = try(data.azurerm_key_vault_secret.sonar_token[0].value, "")
+        }
+      ]
+      repository_variables = []
+    }
     rtp-consumer = {
       env_variables        = [],
       env_secret_variables = []


### PR DESCRIPTION
### List of changes

- **Identities & RBAC**: Added a new User Assigned Identity (`azurerm_user_assigned_identity.sender_v2`), Key Vault access policy (`azurerm_key_vault_access_policy.access_policy_sender_v2_kv`), and Storage Blob Data Reader role assignment (`azurerm_role_assignment.storage_account_to_sender_v2_identity`) in `src/70_domains/srtp_app/01_identities.tf`. These resources are restricted to non-production environments (`dev`, `uat`) via `count`.
- **Kubernetes Secrets**: Added a new Kubernetes fileshare secret (`kubernetes_secret.rtp_sender_v2_fileshare`) in `src/70_domains/srtp_app/10_k8s_secrets.tf`, restricted to non-production environments (`dev`, `uat`) via `count`.
- **ArgoCD**: Registered the new `rtp-sender-v2` microservice in ArgoCD (`30_argocd_domain.tf`), restricting its deployment environments to `["dev", "uat"]`.
- **Domain Locals**: Conditionally appended `"rtp-sender-v2"` to the `repositories` list in `src/70_domains/srtp_common/99_locals.tf` only for non-production environments (`dev`, `uat`), which conditionally configures GitHub Actions federated identity credentials.
- **GitHub Provisioning**: Registered `rtp-sender-v2` in the repository settings map in `src/91_github/srtp/99_locals.tf` to provision repository secrets (`SLACK_WEBHOOK_URL`, `GIT_PAT`, `SONAR_TOKEN`) for all environments.
- **Documentation**: Regenerated resources tables in `src/70_domains/srtp_app/README.md`.

### Motivation and context

This change configures the necessary cloud infrastructure, Kubernetes secrets, ArgoCD manifests, and GitHub environments/credentials for the new repository `rtp-sender-v2`. 
Per requirements, all application-specific deployment resources (ArgoCD deployment, Azure identities, and Kubernetes fileshare secrets) are kept out of production (`prod`), as `rtp-sender-v2` is only intended to be deployed in DEV and UAT. No database (Cosmos DB), alerts, or workbook configurations were duplicated.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information
