### PR TITLE
feat: [SRTP-2037] update rtp-producer configuration

### DIFF
--- a/src/70_domains/srtp_app/07_gh_runner.tf
+++ b/src/70_domains/srtp_app/07_gh_runner.tf
@@ -12,8 +12,8 @@ module "gh_runner_job" {
   gh_env             = "${var.location_short}-${var.env}"
   gh_repositories = [
     {
-      name       = "rtp-platform-qa", # Not used in prod, but needed for the job to be created
-      short_name = "platform-qa"
+      name       = "rtp-internal", # Not used in prod, but needed for the job to be created. Hosts the rtp-producer service.
+      short_name = "rtp-producer"
     }
   ]
   job = {

--- a/src/70_domains/srtp_app/08_moved.tf
+++ b/src/70_domains/srtp_app/08_moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = module.gh_runner_job.module.container_app_job["rtp-platform-qa"]
+  to   = module.gh_runner_job.module.container_app_job["rtp-internal"]
+}

--- a/src/91_github/srtp/99_locals.tf
+++ b/src/91_github/srtp/99_locals.tf
@@ -102,6 +102,7 @@ locals {
           AZURE_TENANT_ID       = data.azurerm_client_config.current.tenant_id
         }
       ]
+      repository_secrets   = []
       repository_variables = []
     }
   }

--- a/src/91_github/srtp/99_locals.tf
+++ b/src/91_github/srtp/99_locals.tf
@@ -76,6 +76,7 @@ locals {
       repository_variables = []
     }
     rtp-platform-qa = {
+      env                  = ["${var.location_short}-dev", "${var.location_short}-uat"],
       env_variables        = [],
       env_secret_variables = []
       repository_secrets = [

--- a/src/91_github/srtp/99_locals.tf
+++ b/src/91_github/srtp/99_locals.tf
@@ -76,12 +76,22 @@ locals {
       repository_variables = []
     }
     rtp-platform-qa = {
+      env_variables        = [],
+      env_secret_variables = []
+      repository_secrets = [
+        {
+          SLACK_WEBHOOK_URL = data.azurerm_key_vault_secret.slack_webhook.value
+        }
+      ]
+      repository_variables = []
+    }
+    rtp-internal = {
       env = ["${var.location_short}-dev", "${var.location_short}-uat"],
       env_variables = [
         {
           AZURE_RESOURCE_GROUP   = local.aks_resource_group_name
           AZURE_AKS_CLUSTER_NAME = local.aks_name
-          DEPLOYMENT_NAME        = "rtp-platform-qa"
+          DEPLOYMENT_NAME        = "rtp-producer"
           NAMESPACE              = var.domain
         }
       ],
@@ -90,11 +100,6 @@ locals {
           AZURE_CLIENT_ID       = data.azurerm_user_assigned_identity.cd_job_github_runner.client_id
           AZURE_SUBSCRIPTION_ID = data.azurerm_subscription.current.subscription_id
           AZURE_TENANT_ID       = data.azurerm_client_config.current.tenant_id
-        }
-      ]
-      repository_secrets = [
-        {
-          SLACK_WEBHOOK_URL = data.azurerm_key_vault_secret.slack_webhook.value
         }
       ]
       repository_variables = []


### PR DESCRIPTION
### List of changes

- `src/70_domains/srtp_app/07_gh_runner.tf`: updated the `gh_repositories` list on the `gh_runner_job` module — the entry previously named `rtp-platform-qa` (`short_name = "platform-qa"`) is now `name = "rtp-internal"` (`short_name = "rtp-producer"`). This is the GitHub repository federation used to let the self-hosted Actions runner accept jobs from the repo that now hosts the producer's CI/CD workflow.
- `src/70_domains/srtp_app/08_moved.tf` (new): adds a `moved` block for `module.gh_runner_job.module.container_app_job["rtp-platform-qa"]` → `["rtp-internal"]`. The shared self-hosted runner Container App Job is a single per-domain resource whose Azure name does **not** depend on the repo name, only on the `for_each` key. Without this block, renaming the `gh_repositories` entry above would make Terraform plan a destroy+create of the *existing* running Container App Job, colliding with the object already in Azure (`already exists` error). This block tells Terraform it's the same object, just re-addressed, so the change is applied in place with no downtime.
- `src/91_github/srtp/99_locals.tf`: split the previous `rtp-platform-qa` map entry into two:
  - `rtp-platform-qa` — kept, still scoped to `env = ["itn-dev", "itn-uat"]` as before, now only carries `repository_secrets.SLACK_WEBHOOK_URL` (still required by that repo's own `send_slack_notification.yml`, unrelated to the producer)
  - `rtp-internal` (new) — carries the environment-scoped (`itn-dev`/`itn-uat`) variables/secrets previously used to deploy the producer: `AZURE_RESOURCE_GROUP`, `AZURE_AKS_CLUSTER_NAME`, `DEPLOYMENT_NAME` (renamed from `"rtp-platform-qa"` to `"rtp-producer"`), `NAMESPACE`, plus `AZURE_CLIENT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`

No new Azure resources are created or destroyed by this change: Key Vault, Event Hub, and its private DNS record are untouched. The shared runner Container App Job is updated in place (not recreated). Only the GitHub repository/environment-level configuration (federated credentials, Actions variables/secrets, self-hosted runner registration) is retargeted.

### Motivation and context

The GPD message producer microservice ("gpd-test") is being relocated from the `rtp-platform-qa` repository to `rtp-internal` (as `rtp-producer/`), since it is a standalone runtime service and not a test suite. Its CI/CD pipeline (Docker build + AKS deploy) now lives in `rtp-internal`, so the GitHub Actions runner federation and the deploy-time environment variables/secrets provisioned by this repository must point to the new repository instead. This PR keeps the deployed Kubernetes resource name consistent with the new service identity (`rtp-producer`) while preserving the unrelated `SLACK_WEBHOOK_URL` secret and environment scoping still needed by `rtp-platform-qa`.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

> These are internal/test environment resources (`itn-dev`/`itn-uat`), not production. No production Azure resource is modified.

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

> `terraform plan` is expected to show: destroy/recreate of the GitHub repository environment variables/secrets and federated identity credential currently attached to `rtp-platform-qa`, and their creation on `rtp-internal` (expected, repo-scoped resources); an in-place move (not destroy/create) of the shared Container App Job thanks to the `moved` block; no changes to Azure resources (AKS, Key Vault, Event Hub, DNS). Plan output to be attached before merge/apply (executed via the Azure Pipeline, not run locally in this PR).

### Other information
