### PR TITLE
feat: [SRTP-2113] Add Sign on Certificates

### DIFF
--- a/src/70_domains/srtp_common/40_namespace_+_workload_identity.tf
+++ b/src/70_domains/srtp_common/40_namespace_+_workload_identity.tf
@@ -24,7 +24,7 @@ module "workload_identity_configuration" {
   namespace                             = var.domain
 
   key_vault_id                      = data.azurerm_key_vault.domain_kv.id
-  key_vault_certificate_permissions = ["Get"]
+  key_vault_certificate_permissions = ["Get", "Sign"]
   key_vault_key_permissions         = ["Get"]
   key_vault_secret_permissions      = ["Get"]
 

--- a/src/70_domains/srtp_common/40_namespace_+_workload_identity.tf
+++ b/src/70_domains/srtp_common/40_namespace_+_workload_identity.tf
@@ -24,8 +24,8 @@ module "workload_identity_configuration" {
   namespace                             = var.domain
 
   key_vault_id                      = data.azurerm_key_vault.domain_kv.id
-  key_vault_certificate_permissions = ["Get", "Sign"]
-  key_vault_key_permissions         = ["Get"]
+  key_vault_certificate_permissions = ["Get"]
+  key_vault_key_permissions         = ["Get", "Sign"]
   key_vault_secret_permissions      = ["Get"]
 
   service_account_image_pull_secret_names = [kubernetes_secret.ghcr_secret.metadata[0].name]


### PR DESCRIPTION
### List of changes

Added `"Sign"` to the `key_vault_certificate_permissions` of the `workload_identity_configuration` module in `src/70_domains/srtp_common/40_namespace_+_workload_identity.tf`.

The permission list goes from `["Get"]` to `["Get", "Sign"]`.

### Motivation and context

The SRTP workload identity needs the `Sign` permission on the domain Key Vault to perform certificate signing operations. Without this permission, any service relying on the workload identity to sign payloads or tokens using Key Vault certificates would fail with an authorization error.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources
- [ ] Chore: change that does not affect functionality

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

Only the certificate permissions on the workload identity's Key Vault access policy are affected. Key and secret permissions (`Get`) are unchanged.

---

### If PR is partially applied, why? (reserved to mantainers)

N/A
